### PR TITLE
Exp/use cma sdk

### DIFF
--- a/src/ContentfulWrapper.js
+++ b/src/ContentfulWrapper.js
@@ -16,11 +16,8 @@ const getPublishedSuppliers = async () => {
   });
 };
 
-const updateSupplier = async (pair) => {
-  const client = contentful.createClient({
-    accessToken: import.meta.env.VITE_REACT_APP_CMA_TOKEN,
-  });
-  const space = await client.getSpace(
+const updateSupplier = async (pair, cma) => {
+  const space = await cma.getSpace(
     import.meta.env.VITE_REACT_APP_CONTENTFUL_SPACE_ID,
   );
   const env = await space.getEnvironment(
@@ -36,11 +33,8 @@ const updateSupplier = async (pair) => {
   return contentfulSupplier.update();
 };
 
-const createSupplier = async (pair) => {
-  const client = contentful.createClient({
-    accessToken: import.meta.env.VITE_REACT_APP_CMA_TOKEN,
-  });
-  const space = await client.getSpace(
+const createSupplier = async (pair, cma) => {
+  const space = await cma.getSpace(
     import.meta.env.VITE_REACT_APP_CONTENTFUL_SPACE_ID,
   );
   const env = await space.getEnvironment(

--- a/src/ContentfulWrapper.js
+++ b/src/ContentfulWrapper.js
@@ -1,4 +1,3 @@
-import * as contentful from "contentful-management";
 import mapSupplierToContentfulFields from "./helpers/mapSupplierToContentfulFields";
 
 const getPublishedSuppliers = async (cma) => {

--- a/src/ContentfulWrapper.js
+++ b/src/ContentfulWrapper.js
@@ -1,11 +1,8 @@
 import * as contentful from "contentful-management";
 import mapSupplierToContentfulFields from "./helpers/mapSupplierToContentfulFields";
 
-const getPublishedSuppliers = async () => {
-  const client = contentful.createClient({
-    accessToken: import.meta.env.VITE_REACT_APP_CMA_TOKEN,
-  });
-  const space = await client.getSpace(
+const getPublishedSuppliers = async (cma) => {
+  const space = await cma.getSpace(
     import.meta.env.VITE_REACT_APP_CONTENTFUL_SPACE_ID,
   );
   const env = await space.getEnvironment(

--- a/src/components/screens/ProcessScreen.jsx
+++ b/src/components/screens/ProcessScreen.jsx
@@ -7,14 +7,19 @@ import { addContentfulSupplier } from "../../state/contentfulSupplierSlice";
 import SuppliersInFileAndContentful from "../SuppliersInFileAndContentful";
 import SuppliersNotInContentful from "../SuppliersNotInContentful";
 import SuppliersNotInFile from "../SuppliersNotInFile";
+import { createClient } from "contentful-management";
+import { useSDK } from "@contentful/react-apps-toolkit";
 
 const ProcessScreen = () => {
+  const sdk = useSDK();
+  const cma = createClient({ apiAdapter: sdk.cmaAdapter });
+
   const status = useSelector((state) => state.appStatus.value);
   const dispatch = useDispatch();
 
   useEffect(() => {
     if (status === AppStatus.FETCHING_CONTENTFUL_SUPPLIERS) {
-      getPublishedSuppliers().then((suppliers) => {
+      getPublishedSuppliers(cma).then((suppliers) => {
         suppliers.items.forEach((s) => {
           dispatch(
             addContentfulSupplier({

--- a/src/components/screens/ProcessScreen.jsx
+++ b/src/components/screens/ProcessScreen.jsx
@@ -34,7 +34,7 @@ const ProcessScreen = () => {
 
       dispatch(setAppStatus(AppStatus.FETCHED_CONTENTFUL_SUPPLIERS));
     }
-  }, [status, dispatch]);
+  }, [status, dispatch, cma]);
 
   return (
     <React.Fragment>

--- a/src/components/screens/ProcessScreen.spec.jsx
+++ b/src/components/screens/ProcessScreen.spec.jsx
@@ -4,6 +4,14 @@ import { renderWithProvider } from "../../../test/utils/render-with-provider";
 import ProcessScreen from "./ProcessScreen";
 import { FETCHING_CONTENTFUL_SUPPLIERS } from "../../constants/app-status";
 
+vi.mock("@contentful/react-apps-toolkit", () => {
+  return {
+    useSDK: () => {
+      return {};
+    },
+  };
+});
+
 // we don't want to actually call Contentful in the tests
 vi.mock("../../ContentfulWrapper.js", () => {
   return {

--- a/src/components/screens/ScheduleScreen.jsx
+++ b/src/components/screens/ScheduleScreen.jsx
@@ -20,8 +20,14 @@ import { setAppStatus } from "../../state/appStatusSlice";
 import { Box, Heading, Paragraph, Table } from "@contentful/f36-components";
 import SuppliersToBeCreated from "../SuppliersToBeCreated";
 import SuppliersToBeUnpublished from "../SuppliersToBeUnpublished";
+import { useSDK } from "@contentful/react-apps-toolkit";
+import { createClient } from "contentful-management";
 
 const ScheduleScreen = () => {
+  const sdk = useSDK();
+
+  const cma = createClient({ apiAdapter: sdk.cmaAdapter });
+
   const dispatch = useDispatch();
   const status = useSelector((state) => state.appStatus.value);
 
@@ -31,7 +37,7 @@ const ScheduleScreen = () => {
   useEffect(() => {
     if (status === PROCESSING_SUPPLIERS) {
       suppliersToBeUpdated.forEach((pair) => {
-        updateSupplier(pair)
+        updateSupplier(pair, cma)
           .then(() => {
             dispatch(
               setSupplier({
@@ -52,7 +58,7 @@ const ScheduleScreen = () => {
       });
 
       suppliersToBeCreated.forEach((pair) => {
-        createSupplier(pair)
+        createSupplier(pair, cma)
           .then((result) => {
             console.log(result);
             dispatch(

--- a/src/components/screens/ScheduleScreen.jsx
+++ b/src/components/screens/ScheduleScreen.jsx
@@ -82,7 +82,7 @@ const ScheduleScreen = () => {
 
       dispatch(setAppStatus(PROCESSED_SUPPLIERS));
     }
-  }, [suppliersToBeCreated, suppliersToBeUpdated, dispatch, status]);
+  }, [suppliersToBeCreated, suppliersToBeUpdated, dispatch, status, cma]);
 
   return (
     <Box marginTop="spacingXl" marginBottom="spacingXl">


### PR DESCRIPTION
Following on from @cnorthwood's comment in https://github.com/citizensadvice/contentful-csr-upload/pull/47#discussion_r1732956612, I did some more research into the SDK.  It has a `cmaAdapter` that you can use to avoid initialising the `contentful-management` client with a CMA token, which is great.

This blurs the boundaries of the `ContentfulWrapper` a bit, because you can't access the `sdk` object outside of a functional component, but that object is already mocked in tests so this seems like a good trade off to me.