### PR TITLE
Feat/loading state process screen

### DIFF
--- a/src/components/LoadingTableRows.jsx
+++ b/src/components/LoadingTableRows.jsx
@@ -2,9 +2,8 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { Skeleton } from "@contentful/f36-components";
 
-const LoadingTable = ({ children, rowCount, colCount, showOnStatus }) => {
+const LoadingTableRows = ({ children, rowCount, colCount, showOnStatus }) => {
   const appStatus = useSelector((state) => state.appStatus.value);
-  console.log(appStatus, showOnStatus);
   return appStatus === showOnStatus ? (
     children
   ) : (
@@ -12,4 +11,4 @@ const LoadingTable = ({ children, rowCount, colCount, showOnStatus }) => {
   );
 };
 
-export default LoadingTable;
+export default LoadingTableRows;

--- a/src/components/LoadingTableRows.jsx
+++ b/src/components/LoadingTableRows.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Skeleton } from "@contentful/f36-components";
+
+const LoadingTable = ({ children, rowCount, colCount, showOnStatus }) => {
+  const appStatus = useSelector((state) => state.appStatus.value);
+  console.log(appStatus, showOnStatus);
+  return appStatus === showOnStatus ? (
+    children
+  ) : (
+    <Skeleton.Row rowCount={rowCount} columnCount={colCount} />
+  );
+};
+
+export default LoadingTable;

--- a/src/components/LoadingTableRows.spec.jsx
+++ b/src/components/LoadingTableRows.spec.jsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, afterEach } from "vitest";
+
+import LoadingTableRows from "./LoadingTableRows";
+import {
+  FETCHED_CONTENTFUL_SUPPLIERS,
+  FETCHING_CONTENTFUL_SUPPLIERS,
+} from "../constants/app-status";
+import { Paragraph, Table } from "@contentful/f36-components";
+import { renderWithProvider } from "../../test/utils/render-with-provider";
+import { cleanup, getByText, queryByRole } from "@testing-library/react";
+
+describe("LoadingTableComponent", () => {
+  const loadingTable = (
+    <Table>
+      <Table.Body>
+        <LoadingTableRows
+          showOnStatus={FETCHED_CONTENTFUL_SUPPLIERS}
+          rowCount={1}
+          colCount={1}
+        >
+          <Table.Row>
+            <Table.Cell>
+              <Paragraph>I am the content</Paragraph>
+            </Table.Cell>
+          </Table.Row>
+        </LoadingTableRows>
+      </Table.Body>
+    </Table>
+  );
+
+  afterEach(() => cleanup());
+
+  it("displays a loading animation when not in 'show on status' status", () => {
+    const { queryByRole, queryByText } = renderWithProvider(loadingTable, {
+      preloadedState: { appStatus: { value: FETCHING_CONTENTFUL_SUPPLIERS } },
+    });
+    expect(queryByText("I am the content")).toBeFalsy();
+    expect(queryByRole("img", { name: "Loading component..." })).toBeTruthy();
+  });
+
+  it("displays the children when not loading", () => {
+    const { queryByRole, getByText } = renderWithProvider(loadingTable, {
+      preloadedState: { appStatus: { value: FETCHED_CONTENTFUL_SUPPLIERS } },
+    });
+    expect(getByText("I am the content")).toBeTruthy();
+    expect(queryByRole("img", { name: "Loading component..." })).toBeFalsy();
+  });
+});

--- a/src/components/LoadingTableRows.spec.jsx
+++ b/src/components/LoadingTableRows.spec.jsx
@@ -7,7 +7,7 @@ import {
 } from "../constants/app-status";
 import { Paragraph, Table } from "@contentful/f36-components";
 import { renderWithProvider } from "../../test/utils/render-with-provider";
-import { cleanup, getByText, queryByRole } from "@testing-library/react";
+import { cleanup } from "@testing-library/react";
 
 describe("LoadingTableComponent", () => {
   const loadingTable = (

--- a/src/components/SuppliersInFileAndContentful.jsx
+++ b/src/components/SuppliersInFileAndContentful.jsx
@@ -9,6 +9,8 @@ import {
   Table,
 } from "@contentful/f36-components";
 import { getType } from "../helpers/getType";
+import LoadingTableRows from "./LoadingTableRows";
+import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
 const SuppliersInFileAndContentful = () => {
   const suppliersInFileAndContentful = useSelector(
@@ -35,15 +37,21 @@ const SuppliersInFileAndContentful = () => {
             </Table.Row>
           </Table.Head>
           <Table.Body>
-            {suppliersInFileAndContentful.map((pair) => {
-              return (
-                <Table.Row key={pair.supplier.id}>
-                  <Table.Cell>{pair.supplier.name}</Table.Cell>
-                  <Table.Cell>{pair.contentfulSupplier.name}</Table.Cell>
-                  <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
-                </Table.Row>
-              );
-            })}
+            <LoadingTableRows
+              colCount={3}
+              rowCount={3}
+              showOnStatus={FETCHED_CONTENTFUL_SUPPLIERS}
+            >
+              {suppliersInFileAndContentful.map((pair) => {
+                return (
+                  <Table.Row key={pair.supplier.id}>
+                    <Table.Cell>{pair.supplier.name}</Table.Cell>
+                    <Table.Cell>{pair.contentfulSupplier.name}</Table.Cell>
+                    <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
+                  </Table.Row>
+                );
+              })}
+            </LoadingTableRows>
           </Table.Body>
         </Table>
       </React.Fragment>
@@ -58,7 +66,8 @@ const SuppliersInFileAndContentful = () => {
         renderMatchedSuppliers()
       ) : (
         <Paragraph>
-          No suppliers in the spreadsheet were found in Contentful
+          There are no suppliers in the spreadsheet that aren't already in
+          Contentful.
         </Paragraph>
       )}
     </Box>

--- a/src/components/SuppliersInFileAndContentful.spec.jsx
+++ b/src/components/SuppliersInFileAndContentful.spec.jsx
@@ -7,6 +7,7 @@ import {
   suppliers,
   contentfulSuppliers,
 } from "../../test/fixtures/process-screen-state";
+import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
 describe("SuppliersFoundInContentful component", () => {
   const { getByRole, queryByText } = renderWithProvider(
@@ -15,6 +16,7 @@ describe("SuppliersFoundInContentful component", () => {
       preloadedState: {
         suppliers: { value: suppliers },
         contentfulSuppliers: { value: contentfulSuppliers },
+        appStatus: { value: FETCHED_CONTENTFUL_SUPPLIERS },
       },
     },
   );

--- a/src/components/SuppliersNotInContentful.jsx
+++ b/src/components/SuppliersNotInContentful.jsx
@@ -9,6 +9,8 @@ import {
   Table,
 } from "@contentful/f36-components";
 import { getType } from "../helpers/getType";
+import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
+import LoadingTableRows from "./LoadingTableRows";
 
 const SuppliersNotInContentful = () => {
   const suppliersNotInContentful = useSelector(getSuppliersNotInContentful);
@@ -23,14 +25,20 @@ const SuppliersNotInContentful = () => {
           </Table.Row>
         </Table.Head>
         <Table.Body>
-          {suppliersNotInContentful.map((pair) => {
-            return (
-              <Table.Row key={pair.supplier.id}>
-                <Table.Cell>{pair.supplier.name}</Table.Cell>
-                <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
-              </Table.Row>
-            );
-          })}
+          <LoadingTableRows
+            colCount={3}
+            rowCount={3}
+            showOnStatus={FETCHED_CONTENTFUL_SUPPLIERS}
+          >
+            {suppliersNotInContentful.map((pair) => {
+              return (
+                <Table.Row key={pair.supplier.id}>
+                  <Table.Cell>{pair.supplier.name}</Table.Cell>
+                  <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
+                </Table.Row>
+              );
+            })}
+          </LoadingTableRows>
         </Table.Body>
       </Table>
     );

--- a/src/components/SuppliersNotInContentful.spec.jsx
+++ b/src/components/SuppliersNotInContentful.spec.jsx
@@ -7,6 +7,7 @@ import {
   suppliers,
   contentfulSuppliers,
 } from "../../test/fixtures/process-screen-state";
+import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
 describe("SuppliersNotInContentful component", () => {
   const { getByRole, queryByText } = renderWithProvider(
@@ -15,6 +16,7 @@ describe("SuppliersNotInContentful component", () => {
       preloadedState: {
         suppliers: { value: suppliers },
         contentfulSuppliers: { value: contentfulSuppliers },
+        appStatus: { value: FETCHED_CONTENTFUL_SUPPLIERS },
       },
     },
   );

--- a/src/components/SuppliersNotInFile.jsx
+++ b/src/components/SuppliersNotInFile.jsx
@@ -3,6 +3,8 @@ import { useSelector } from "react-redux";
 import { getContentfulSuppliersNotInFile } from "../selectors";
 import { Box, Heading, Paragraph, Table } from "@contentful/f36-components";
 import { getType } from "../helpers/getType";
+import LoadingTableRows from "./LoadingTableRows";
+import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
 const SuppliersNotInFile = () => {
   const suppliersNotInFile = useSelector(getContentfulSuppliersNotInFile);
@@ -17,16 +19,22 @@ const SuppliersNotInFile = () => {
           </Table.Row>
         </Table.Head>
         <Table.Body>
-          {suppliersNotInFile.map((pair) => {
-            return (
-              <Table.Row key={pair.contentfulSupplier.name}>
-                <Table.Cell>{pair.contentfulSupplier.name}</Table.Cell>
-                <Table.Cell>
-                  {getType(!pair.contentfulSupplier.dataAvailable)}
-                </Table.Cell>
-              </Table.Row>
-            );
-          })}
+          <LoadingTableRows
+            showOnStatus={FETCHED_CONTENTFUL_SUPPLIERS}
+            rowCount={3}
+            colCount={2}
+          >
+            {suppliersNotInFile.map((pair) => {
+              return (
+                <Table.Row key={pair.contentfulSupplier.name}>
+                  <Table.Cell>{pair.contentfulSupplier.name}</Table.Cell>
+                  <Table.Cell>
+                    {getType(!pair.contentfulSupplier.dataAvailable)}
+                  </Table.Cell>
+                </Table.Row>
+              );
+            })}
+          </LoadingTableRows>
         </Table.Body>
       </Table>
     );

--- a/src/components/SuppliersNotInFile.spec.jsx
+++ b/src/components/SuppliersNotInFile.spec.jsx
@@ -7,6 +7,7 @@ import {
   suppliers,
   contentfulSuppliers,
 } from "../../test/fixtures/process-screen-state";
+import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
 describe("SuppliersNotInFile component", () => {
   const { getByRole, queryByText } = renderWithProvider(
@@ -15,6 +16,7 @@ describe("SuppliersNotInFile component", () => {
       preloadedState: {
         suppliers: { value: suppliers },
         contentfulSuppliers: { value: contentfulSuppliers },
+        appStatus: { value: FETCHED_CONTENTFUL_SUPPLIERS },
       },
     },
   );

--- a/src/components/screens/ProcessScreen.jsx
+++ b/src/components/screens/ProcessScreen.jsx
@@ -44,9 +44,8 @@ const ProcessScreen = () => {
             );
           }
         });
+        dispatch(setAppStatus(AppStatus.FETCHED_CONTENTFUL_SUPPLIERS));
       });
-
-      dispatch(setAppStatus(AppStatus.FETCHED_CONTENTFUL_SUPPLIERS));
     }
   }, [status, dispatch, cma]);
 


### PR DESCRIPTION
The `ProcessScreen` needs a loading state, since incorrect information is displayed whilst entries are fetched from Contentful.  Because there are no Contentful suppliers in the store when the component is loaded, the screen displays all suppliers in the file as 'to be created' - which is wrong.   It's only shown briefly but the loading state eliminates it completely.