### PR TITLE
Feat/schedule sidebar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["react-app", "prettier"]
+  "extends": ["react-app", "prettier"],
+  "rules": {
+    "no-unused-vars": ["error"]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@vitejs/plugin-react": "4.3.1",
         "cross-env": "7.0.3",
+        "dateformat": "^5.0.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-react-app": "^7.0.1",
@@ -6285,6 +6286,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+      "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "4.3.1",
     "cross-env": "7.0.3",
+    "dateformat": "^5.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-react-app": "^7.0.1",

--- a/src/ContentfulWrapper.js
+++ b/src/ContentfulWrapper.js
@@ -42,4 +42,40 @@ const createSupplier = async (pair, cma) => {
   return env.createEntry("energySupplier", contentfulFields);
 };
 
-export { getPublishedSuppliers, updateSupplier, createSupplier };
+const scheduleAction = async (id, iso_date, action, cma) => {
+  const space = await cma.getSpace(
+    import.meta.env.VITE_REACT_APP_CONTENTFUL_SPACE_ID,
+  );
+  const env = await space.getEnvironment(
+    import.meta.env.VITE_REACT_APP_CONTENTFUL_ENV,
+  );
+
+  return space.createScheduledAction({
+    entity: {
+      sys: {
+        type: "Link",
+        linkType: "Entry",
+        id: id,
+      },
+    },
+    environment: {
+      sys: {
+        type: "Link",
+        linkType: "Environment",
+        id: env.sys.id,
+      },
+    },
+    action: action,
+    scheduledFor: {
+      datetime: iso_date,
+      timezone: "Europe/London",
+    },
+  });
+};
+
+export {
+  getPublishedSuppliers,
+  updateSupplier,
+  createSupplier,
+  scheduleAction,
+};

--- a/src/components/SchedulingForm.jsx
+++ b/src/components/SchedulingForm.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Datepicker,
+  DateTime,
+  Paragraph,
+  Stack,
+  Text,
+  TextInput,
+} from "@contentful/f36-components";
+import { ErrorCircleIcon } from "@contentful/f36-icons";
+import { setAppStatus } from "../state/appStatusSlice";
+import { setScheduleTime } from "../state/scheduleTimeSlice";
+import { PROCESSED_SUPPLIERS, SCHEDULE_UPDATES } from "../constants/app-status";
+import { useDispatch, useSelector } from "react-redux";
+import { getAllContentfulActionsSuccessful } from "../selectors";
+
+const SchedulingForm = () => {
+  const dispatch = useDispatch();
+
+  const [selectedDay, setSelectedDay] = useState(new Date());
+  const [time, setTime] = useState("00:01");
+  const [error, setError] = useState();
+
+  const appStatus = useSelector((state) => state.appStatus.value);
+  const uploadsSuccessful = useSelector(getAllContentfulActionsSuccessful);
+  const date = useSelector((state) => state.scheduleTime.value);
+
+  const allowScheduling =
+    appStatus === PROCESSED_SUPPLIERS &&
+    uploadsSuccessful &&
+    error === undefined;
+
+  useEffect(() => {
+    setError();
+
+    const [hours, minutes] = time.split(":");
+    let newDate = new Date(selectedDay);
+    newDate.setHours(hours, minutes);
+    const parsedDate = Date.parse(newDate);
+
+    if (Number.isNaN(parsedDate)) {
+      setError("Enter a valid date and time (HH:MM)");
+    } else {
+      dispatch(setScheduleTime(newDate.toISOString()));
+    }
+  }, [selectedDay, time, dispatch]);
+
+  return (
+    <Box marginTop="spacingM">
+      <Stack flexDirection="column" alignItems="start">
+        <Datepicker selected={selectedDay} onSelect={setSelectedDay} />
+        <TextInput
+          type="text"
+          aria-label="Enter time"
+          placeholder="HH:MM"
+          onBlur={(e) => setTime(e.target.value)}
+          isInvalid={error}
+          pattern="0..9"
+        />
+        {error ? (
+          <Stack alignItems="top">
+            <ErrorCircleIcon variant="negative" />
+            <Text fontColor="red600">{error}</Text>
+          </Stack>
+        ) : (
+          <React.Fragment>
+            <Paragraph>Publishing / unpublishing will happen on:</Paragraph>
+            <Paragraph>
+              <strong>
+                <DateTime date={date} />
+              </strong>
+            </Paragraph>
+          </React.Fragment>
+        )}
+        <Button
+          variant="primary"
+          isDisabled={!allowScheduling}
+          onClick={() => dispatch(setAppStatus(SCHEDULE_UPDATES))}
+        >
+          Schedule Update
+        </Button>
+      </Stack>
+    </Box>
+  );
+};
+
+export default SchedulingForm;

--- a/src/components/SchedulingForm.spec.jsx
+++ b/src/components/SchedulingForm.spec.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderWithProvider } from "../../test/utils/render-with-provider";
+import {
+  suppliers,
+  contentfulSuppliers,
+} from "../../test/fixtures/schedule-sidebar-state";
+import * as AppStatus from "../constants/app-status";
+import { cleanup } from "@testing-library/react";
+import dateFormat from "dateformat";
+import { userEvent } from "@testing-library/user-event";
+import SchedulingForm from "./SchedulingForm";
+
+const defaultComponentSetup = () => {
+  return renderWithProvider(<SchedulingForm />, {
+    preloadedState: {
+      suppliers: { value: suppliers },
+      contentfulSuppliers: { value: contentfulSuppliers },
+      appStatus: { value: AppStatus.PROCESSED_SUPPLIERS },
+    },
+  });
+};
+
+describe("ScheduleSidebar Component", () => {
+  afterEach(() => cleanup());
+
+  it("selects today and 12:01 PM as the default time", () => {
+    const { getByText } = defaultComponentSetup();
+
+    const todayString = `${dateFormat(new Date(), "ddd, dd mmm yyyy")} at 12:01 AM`;
+    expect(getByText(todayString)).toBeTruthy();
+  });
+
+  it("shows the correct date when a day is selected from the calendar", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const dateInput = getByRole("textbox", { name: "Enter date" });
+    const user = await userEvent.setup();
+
+    await user.click(dateInput);
+    await user.keyboard("01 Sep 2024");
+
+    expect(getByText(/01 Sep 2024 at 12:01 AM/)).toBeTruthy();
+  });
+
+  it("shows an error message and disables the button when an invalid date is entered", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const dateInput = getByRole("textbox", { name: "Enter date" });
+    const user = await userEvent.setup();
+
+    await user.click(dateInput);
+    await user.keyboard("I am not a date");
+
+    await user.tab(dateInput);
+
+    expect(getByText("Enter a valid date and time (HH:MM)")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Schedule Update", disabled: true }),
+    ).toBeTruthy();
+  });
+
+  it("shows the correct time when a valid time is entered", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const timeInput = getByRole("textbox", { name: "Enter time" });
+    const user = await userEvent.setup();
+
+    await user.click(timeInput);
+    await user.keyboard("13:01");
+    await user.tab(timeInput);
+
+    expect(getByText(/at 1:01 PM/)).toBeTruthy();
+  });
+
+  it("shows an error message and disables the button when an invalid time is entered", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const timeInput = getByRole("textbox", { name: "Enter time" });
+    const user = await userEvent.setup();
+
+    await user.click(timeInput);
+    await user.keyboard("I am not a time");
+    await user.tab(timeInput);
+
+    expect(getByText("Enter a valid date and time (HH:MM)")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Schedule Update", disabled: true }),
+    ).toBeTruthy();
+  });
+
+  it("disables the button when the scheduling is underway", () => {
+    const { getByRole } = renderWithProvider(<SchedulingForm />, {
+      preloadedState: {
+        suppliers: { value: suppliers },
+        contentfulSuppliers: { value: contentfulSuppliers },
+        appStatus: { value: AppStatus.SCHEDULING_UPDATES },
+      },
+    });
+
+    expect(
+      getByRole("button", { name: "Schedule Update", disabled: true }),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/screens/ScheduleScreen.jsx
+++ b/src/components/screens/ScheduleScreen.jsx
@@ -7,6 +7,7 @@ import {
 } from "../../selectors";
 import { useEffect } from "react";
 import {
+  PROCESS_SUPPLIERS,
   PROCESSED_SUPPLIERS,
   PROCESSING_SUPPLIERS,
 } from "../../constants/app-status";
@@ -35,8 +36,9 @@ const ScheduleScreen = () => {
   const suppliersToBeCreated = useSelector(getSuppliersNotInContentful);
 
   useEffect(() => {
-    if (status === PROCESSING_SUPPLIERS) {
-      const contentfulActions = [];
+    const contentfulActions = [];
+
+    if (status === PROCESS_SUPPLIERS) {
       suppliersToBeUpdated.forEach((pair) => {
         contentfulActions.push(
           updateSupplier(pair, cma)
@@ -84,6 +86,8 @@ const ScheduleScreen = () => {
             }),
         );
       });
+
+      dispatch(setAppStatus(PROCESSING_SUPPLIERS));
 
       Promise.all(contentfulActions).then(() => {
         dispatch(setAppStatus(PROCESSED_SUPPLIERS));

--- a/src/components/screens/ScheduleScreen.jsx
+++ b/src/components/screens/ScheduleScreen.jsx
@@ -36,51 +36,58 @@ const ScheduleScreen = () => {
 
   useEffect(() => {
     if (status === PROCESSING_SUPPLIERS) {
+      const contentfulActions = [];
       suppliersToBeUpdated.forEach((pair) => {
-        updateSupplier(pair, cma)
-          .then(() => {
-            dispatch(
-              setSupplier({
-                supplierId: pair.supplier.id,
-                status: TO_BE_PUBLISHED,
-              }),
-            );
-          })
-          .catch((error) => {
-            dispatch(
-              setSupplier({
-                supplierId: pair.supplier.id,
-                status: CONTENTFUL_PUT_ERROR,
-              }),
-            );
-            console.error(error.message);
-          });
+        contentfulActions.push(
+          updateSupplier(pair, cma)
+            .then(() => {
+              dispatch(
+                setSupplier({
+                  supplierId: pair.supplier.id,
+                  status: TO_BE_PUBLISHED,
+                }),
+              );
+            })
+            .catch((error) => {
+              dispatch(
+                setSupplier({
+                  supplierId: pair.supplier.id,
+                  status: CONTENTFUL_PUT_ERROR,
+                }),
+              );
+              console.error(error.message);
+            }),
+        );
       });
 
       suppliersToBeCreated.forEach((pair) => {
-        createSupplier(pair, cma)
-          .then((result) => {
-            console.log(result);
-            dispatch(
-              setSupplier({
-                supplierId: pair.supplier.id,
-                newContentfulId: result.sys.id,
-                status: TO_BE_PUBLISHED,
-              }),
-            );
-          })
-          .catch((error) => {
-            dispatch(
-              setSupplier({
-                supplierId: pair.supplier.id,
-                status: CONTENTFUL_PUT_ERROR,
-              }),
-            );
-            console.error(error.message);
-          });
+        contentfulActions.push(
+          createSupplier(pair, cma)
+            .then((result) => {
+              console.log(result);
+              dispatch(
+                setSupplier({
+                  supplierId: pair.supplier.id,
+                  newContentfulId: result.sys.id,
+                  status: TO_BE_PUBLISHED,
+                }),
+              );
+            })
+            .catch((error) => {
+              dispatch(
+                setSupplier({
+                  supplierId: pair.supplier.id,
+                  status: CONTENTFUL_PUT_ERROR,
+                }),
+              );
+              console.error(error.message);
+            }),
+        );
       });
 
-      dispatch(setAppStatus(PROCESSED_SUPPLIERS));
+      Promise.all(contentfulActions).then(() => {
+        dispatch(setAppStatus(PROCESSED_SUPPLIERS));
+      });
     }
   }, [suppliersToBeCreated, suppliersToBeUpdated, dispatch, status, cma]);
 

--- a/src/components/screens/ScheduleScreen.jsx
+++ b/src/components/screens/ScheduleScreen.jsx
@@ -66,7 +66,6 @@ const ScheduleScreen = () => {
         contentfulActions.push(
           createSupplier(pair, cma)
             .then((result) => {
-              console.log(result);
               dispatch(
                 setSupplier({
                   supplierId: pair.supplier.id,

--- a/src/components/screens/ScheduleScreen.spec.jsx
+++ b/src/components/screens/ScheduleScreen.spec.jsx
@@ -5,7 +5,6 @@ import ScheduleScreen from "./ScheduleScreen";
 import {
   PROCESS_SUPPLIERS,
   PROCESSED_SUPPLIERS,
-  PROCESSING_SUPPLIERS,
 } from "../../constants/app-status";
 
 import {

--- a/src/components/screens/ScheduleScreen.spec.jsx
+++ b/src/components/screens/ScheduleScreen.spec.jsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderWithProvider } from "../../../test/utils/render-with-provider";
 import ScheduleScreen from "./ScheduleScreen";
 import {
+  PROCESS_SUPPLIERS,
   PROCESSED_SUPPLIERS,
   PROCESSING_SUPPLIERS,
 } from "../../constants/app-status";
@@ -38,7 +39,7 @@ describe("ScheduleScreen component", () => {
     preloadedState: {
       suppliers: { value: suppliers },
       contentfulSuppliers: { value: contentfulSuppliers },
-      appStatus: { value: PROCESSING_SUPPLIERS },
+      appStatus: { value: PROCESS_SUPPLIERS },
     },
   });
 

--- a/src/components/sidebars/ProcessSidebar.jsx
+++ b/src/components/sidebars/ProcessSidebar.jsx
@@ -25,7 +25,7 @@ const ProcessSidebar = () => {
   const suppliersNotInContentful = useSelector(getSuppliersNotInContentful);
 
   const clickHandler = () => {
-    dispatch(setAppStatus(AppStatus.PROCESSING_SUPPLIERS));
+    dispatch(setAppStatus(AppStatus.PROCESS_SUPPLIERS));
     dispatch(setScreen(SCHEDULE));
   };
 

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -16,8 +16,12 @@ import {
   Text,
 } from "@contentful/f36-components";
 import { ErrorCircleIcon } from "@contentful/f36-icons";
+import { useSelector } from "react-redux";
+import { PROCESSED_SUPPLIERS } from "../../constants/app-status";
 
 const ScheduleSidebar = () => {
+  const appStatus = useSelector((state) => state.appStatus.value);
+
   const [selectedDay, setSelectedDay] = useState(new Date());
   const [time, setTime] = useState("00:01");
 
@@ -38,6 +42,9 @@ const ScheduleSidebar = () => {
       setDate(newDate);
     }
   }, [selectedDay, time]);
+
+  const allowScheduling =
+    appStatus === PROCESSED_SUPPLIERS && error === undefined;
 
   return (
     <React.Fragment>
@@ -73,7 +80,7 @@ const ScheduleSidebar = () => {
               Publishing / unpublishing will happen on <DateTime date={date} />
             </Paragraph>
           )}
-          <Button variant="primary" isDisabled={error}>
+          <Button variant="primary" isDisabled={!allowScheduling}>
             Schedule Update
           </Button>
         </Stack>

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -23,6 +23,7 @@ import {
   SCHEDULING_UPDATES,
 } from "../../constants/app-status";
 import {
+  getAllContentfulActionsSuccessful,
   getContentfulIdsToBePublished,
   getContentfulSuppliersNotInFile,
 } from "../../selectors";
@@ -42,6 +43,7 @@ const ScheduleSidebar = () => {
   const contentfulIdsToUnpublish = suppliersToUnpublish.map(
     (s) => s.contentfulSupplier.contentfulId,
   );
+  const uploadsSuccessful = useSelector(getAllContentfulActionsSuccessful);
 
   const [selectedDay, setSelectedDay] = useState(new Date());
   const [time, setTime] = useState("00:01");
@@ -85,7 +87,9 @@ const ScheduleSidebar = () => {
   });
 
   const allowScheduling =
-    appStatus === PROCESSED_SUPPLIERS && error === undefined;
+    appStatus === PROCESSED_SUPPLIERS &&
+    uploadsSuccessful &&
+    error === undefined;
 
   return (
     <React.Fragment>
@@ -131,7 +135,7 @@ const ScheduleSidebar = () => {
           <Button
             variant="primary"
             isDisabled={!allowScheduling}
-            onClick={() => dispatch(setAppStatus("SCHEDULE_UPDATES"))}
+            onClick={() => dispatch(setAppStatus(SCHEDULE_UPDATES))}
           >
             Schedule Update
           </Button>

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -94,15 +94,17 @@ const ScheduleSidebar = () => {
         <Paragraph marginBottom="spacingM">After the event happens:</Paragraph>
         <List>
           <ListItem>
-            20 suppliers will be <EntityStatusBadge entityStatus="published" />
+            {contentfulIdsToPublish.length} suppliers will be{" "}
+            <EntityStatusBadge entityStatus="published" />
           </ListItem>
           <ListItem>
-            3 suppliers will be <Badge variant="warning">Draft</Badge>
+            {contentfulIdsToUnpublish.length} suppliers will be{" "}
+            <Badge variant="warning">Draft</Badge>
           </ListItem>
         </List>
       </Box>
       <Box marginTop="spacingM">
-        <Stack flexDirection="column">
+        <Stack flexDirection="column" alignItems="start">
           <Datepicker selected={selectedDay} onSelect={setSelectedDay} />
           <TextInput
             type="text"
@@ -117,9 +119,14 @@ const ScheduleSidebar = () => {
               <Text fontColor="red600">{error}</Text>
             </Stack>
           ) : (
-            <Paragraph>
-              Publishing / unpublishing will happen on <DateTime date={date} />
-            </Paragraph>
+            <React.Fragment>
+              <Paragraph>Publishing / unpublishing will happen on:</Paragraph>
+              <Paragraph>
+                <strong>
+                  <DateTime date={date} />
+                </strong>
+              </Paragraph>
+            </React.Fragment>
           )}
           <Button
             variant="primary"

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -112,6 +112,7 @@ const ScheduleSidebar = () => {
           <Datepicker selected={selectedDay} onSelect={setSelectedDay} />
           <TextInput
             type="text"
+            aria-label="Enter time"
             placeholder="HH:MM"
             onBlur={(e) => setTime(e.target.value)}
             isInvalid={error}

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -60,7 +60,7 @@ const ScheduleSidebar = () => {
     const parsedDate = Date.parse(newDate);
 
     if (Number.isNaN(parsedDate)) {
-      setError("Enter a valid date and time (HH:SS)");
+      setError("Enter a valid date and time (HH:MM)");
     } else {
       setDate(newDate.toISOString());
     }

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import {
+  Badge,
+  Box,
+  Button,
+  List,
+  ListItem,
+  Paragraph,
+  SectionHeading,
+  Stack,
+  Subheading,
+  TextInput,
+  Datepicker,
+  EntityStatusBadge,
+  DateTime,
+  Text,
+} from "@contentful/f36-components";
+import { ErrorCircleIcon } from "@contentful/f36-icons";
+
+const ScheduleSidebar = () => {
+  const [selectedDay, setSelectedDay] = useState(new Date());
+  const [time, setTime] = useState("00:01");
+
+  const [date, setDate] = useState();
+  const [error, setError] = useState();
+
+  useEffect(() => {
+    setError();
+
+    const [hours, minutes] = time.split(":");
+    let newDate = new Date(selectedDay);
+    newDate.setHours(hours, minutes);
+    const parsedDate = Date.parse(newDate);
+
+    if (Number.isNaN(parsedDate)) {
+      setError("Enter a valid date and time (HH:SS)");
+    } else {
+      setDate(newDate);
+    }
+  }, [selectedDay, time]);
+
+  return (
+    <React.Fragment>
+      <Box marginTop="spacingM">
+        <SectionHeading>SCHEDULE PUBLISH / UNPUBLISH</SectionHeading>
+        <Paragraph marginBottom="spacingM">After the event happens:</Paragraph>
+        <List>
+          <ListItem>
+            20 suppliers will be <EntityStatusBadge entityStatus="published" />
+          </ListItem>
+          <ListItem>
+            3 suppliers will be <Badge variant="warning">Draft</Badge>
+          </ListItem>
+        </List>
+      </Box>
+      <Box marginTop="spacingM">
+        <Stack flexDirection="column">
+          <Datepicker selected={selectedDay} onSelect={setSelectedDay} />
+          <TextInput
+            type="text"
+            placeholder="HH:MM"
+            onBlur={(e) => setTime(e.target.value)}
+            isInvalid={error}
+            pattern="0..9"
+          />
+          {error ? (
+            <Stack alignItems="top">
+              <ErrorCircleIcon variant="negative" />
+              <Text fontColor="red600">{error}</Text>
+            </Stack>
+          ) : (
+            <Paragraph>
+              Publishing / unpublishing will happen on <DateTime date={date} />
+            </Paragraph>
+          )}
+          <Button variant="primary" isDisabled={error}>
+            Schedule Update
+          </Button>
+        </Stack>
+      </Box>
+    </React.Fragment>
+  );
+};
+
+export default ScheduleSidebar;

--- a/src/components/sidebars/ScheduleSidebar.spec.jsx
+++ b/src/components/sidebars/ScheduleSidebar.spec.jsx
@@ -92,7 +92,7 @@ describe("ScheduleSidebar Component", () => {
 
     await user.tab(dateInput);
 
-    expect(getByText("Enter a valid date and time (HH:SS)")).toBeTruthy();
+    expect(getByText("Enter a valid date and time (HH:MM)")).toBeTruthy();
     expect(
       getByRole("button", { name: "Schedule Update", disabled: true }),
     ).toBeTruthy();
@@ -121,7 +121,7 @@ describe("ScheduleSidebar Component", () => {
     await user.keyboard("I am not a time");
     await user.tab(timeInput);
 
-    expect(getByText("Enter a valid date and time (HH:SS)")).toBeTruthy();
+    expect(getByText("Enter a valid date and time (HH:MM)")).toBeTruthy();
     expect(
       getByRole("button", { name: "Schedule Update", disabled: true }),
     ).toBeTruthy();

--- a/src/components/sidebars/ScheduleSidebar.spec.jsx
+++ b/src/components/sidebars/ScheduleSidebar.spec.jsx
@@ -7,11 +7,10 @@ import {
   contentfulSuppliers,
 } from "../../../test/fixtures/schedule-sidebar-state";
 import * as AppStatus from "../../constants/app-status";
-import { cleanup, getByText } from "@testing-library/react";
+import { cleanup } from "@testing-library/react";
 import dateFormat from "dateformat";
 import { userEvent } from "@testing-library/user-event";
 import { scheduleAction } from "../../ContentfulWrapper";
-import { createClient } from "contentful-management";
 
 vi.mock("contentful-management", () => {
   return {

--- a/src/components/sidebars/ScheduleSidebar.spec.jsx
+++ b/src/components/sidebars/ScheduleSidebar.spec.jsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderWithProvider } from "../../../test/utils/render-with-provider";
+
+import ScheduleSidebar from "./ScheduleSidebar";
+import {
+  suppliers,
+  contentfulSuppliers,
+} from "../../../test/fixtures/schedule-sidebar-state";
+import * as AppStatus from "../../constants/app-status";
+import { cleanup, getByText } from "@testing-library/react";
+import dateFormat from "dateformat";
+import { userEvent } from "@testing-library/user-event";
+import { scheduleAction } from "../../ContentfulWrapper";
+import { createClient } from "contentful-management";
+
+vi.mock("contentful-management", () => {
+  return {
+    createClient: vi.fn(),
+  };
+});
+
+vi.mock("@contentful/react-apps-toolkit", () => {
+  return {
+    useSDK: () => {
+      return {};
+    },
+  };
+});
+
+// we don't want to actually call Contentful in the tests
+vi.mock("../../ContentfulWrapper.js", () => {
+  return {
+    scheduleAction: vi.fn().mockResolvedValue({}),
+  };
+});
+
+const defaultComponentSetup = () => {
+  return renderWithProvider(<ScheduleSidebar />, {
+    preloadedState: {
+      suppliers: { value: suppliers },
+      contentfulSuppliers: { value: contentfulSuppliers },
+      appStatus: { value: AppStatus.PROCESSED_SUPPLIERS },
+    },
+  });
+};
+
+describe("ScheduleSidebar Component", () => {
+  afterEach(() => cleanup());
+
+  it("shows the number of suppliers that will be published", () => {
+    const { getByText } = defaultComponentSetup();
+    expect(
+      getByText(
+        (_, node) => node.textContent === "3 suppliers will be published",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows the number of suppliers that will be unpublished", () => {
+    const { getByText } = defaultComponentSetup();
+    expect(
+      getByText((_, node) => node.textContent === "1 suppliers will be Draft"),
+    ).toBeTruthy();
+  });
+
+  it("selects today and 12:01 PM as the default time", () => {
+    const { getByText } = defaultComponentSetup();
+
+    const todayString = `${dateFormat(new Date(), "ddd, dd mmm yyyy")} at 12:01 AM`;
+    expect(getByText(todayString)).toBeTruthy();
+  });
+
+  it("shows the correct date when a day is selected from the calendar", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const dateInput = getByRole("textbox", { name: "Enter date" });
+    const user = await userEvent.setup();
+
+    await user.click(dateInput);
+    await user.keyboard("01 Sep 2024");
+
+    expect(getByText(/01 Sep 2024 at 12:01 AM/)).toBeTruthy();
+  });
+
+  it("shows an error message and disables the button when an invalid date is entered", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const dateInput = getByRole("textbox", { name: "Enter date" });
+    const user = await userEvent.setup();
+
+    await user.click(dateInput);
+    await user.keyboard("I am not a date");
+
+    await user.tab(dateInput);
+
+    expect(getByText("Enter a valid date and time (HH:SS)")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Schedule Update", disabled: true }),
+    ).toBeTruthy();
+  });
+
+  it("shows the correct time when a valid time is entered", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const timeInput = getByRole("textbox", { name: "Enter time" });
+    const user = await userEvent.setup();
+
+    await user.click(timeInput);
+    await user.keyboard("13:01");
+    await user.tab(timeInput);
+
+    expect(getByText(/at 1:01 PM/)).toBeTruthy();
+  });
+
+  it("shows an error message and disables the button when an invalid time is entered", async () => {
+    const { getByRole, getByText } = defaultComponentSetup();
+
+    const timeInput = getByRole("textbox", { name: "Enter time" });
+    const user = await userEvent.setup();
+
+    await user.click(timeInput);
+    await user.keyboard("I am not a time");
+    await user.tab(timeInput);
+
+    expect(getByText("Enter a valid date and time (HH:SS)")).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Schedule Update", disabled: true }),
+    ).toBeTruthy();
+  });
+
+  it("disables the button when the scheduling is underway", () => {
+    const { getByRole } = renderWithProvider(<ScheduleSidebar />, {
+      preloadedState: {
+        suppliers: { value: suppliers },
+        contentfulSuppliers: { value: contentfulSuppliers },
+        appStatus: { value: AppStatus.SCHEDULING_UPDATES },
+      },
+    });
+
+    expect(
+      getByRole("button", { name: "Schedule Update", disabled: true }),
+    ).toBeTruthy();
+  });
+
+  it("schedules the updates", async () => {
+    const { getByRole } = defaultComponentSetup();
+
+    const scheduleButton = getByRole("button", { name: "Schedule Update" });
+
+    const user = await userEvent.setup();
+    await user.click(scheduleButton);
+
+    // once for each supplier to be published (3)
+    // once for each supplier to be unpublished (1)
+    expect(scheduleAction).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/components/sidebars/ScheduleSidebar.spec.jsx
+++ b/src/components/sidebars/ScheduleSidebar.spec.jsx
@@ -8,7 +8,6 @@ import {
 } from "../../../test/fixtures/schedule-sidebar-state";
 import * as AppStatus from "../../constants/app-status";
 import { cleanup } from "@testing-library/react";
-import dateFormat from "dateformat";
 import { userEvent } from "@testing-library/user-event";
 import { scheduleAction } from "../../ContentfulWrapper";
 
@@ -59,85 +58,6 @@ describe("ScheduleSidebar Component", () => {
     const { getByText } = defaultComponentSetup();
     expect(
       getByText((_, node) => node.textContent === "1 suppliers will be Draft"),
-    ).toBeTruthy();
-  });
-
-  it("selects today and 12:01 PM as the default time", () => {
-    const { getByText } = defaultComponentSetup();
-
-    const todayString = `${dateFormat(new Date(), "ddd, dd mmm yyyy")} at 12:01 AM`;
-    expect(getByText(todayString)).toBeTruthy();
-  });
-
-  it("shows the correct date when a day is selected from the calendar", async () => {
-    const { getByRole, getByText } = defaultComponentSetup();
-
-    const dateInput = getByRole("textbox", { name: "Enter date" });
-    const user = await userEvent.setup();
-
-    await user.click(dateInput);
-    await user.keyboard("01 Sep 2024");
-
-    expect(getByText(/01 Sep 2024 at 12:01 AM/)).toBeTruthy();
-  });
-
-  it("shows an error message and disables the button when an invalid date is entered", async () => {
-    const { getByRole, getByText } = defaultComponentSetup();
-
-    const dateInput = getByRole("textbox", { name: "Enter date" });
-    const user = await userEvent.setup();
-
-    await user.click(dateInput);
-    await user.keyboard("I am not a date");
-
-    await user.tab(dateInput);
-
-    expect(getByText("Enter a valid date and time (HH:MM)")).toBeTruthy();
-    expect(
-      getByRole("button", { name: "Schedule Update", disabled: true }),
-    ).toBeTruthy();
-  });
-
-  it("shows the correct time when a valid time is entered", async () => {
-    const { getByRole, getByText } = defaultComponentSetup();
-
-    const timeInput = getByRole("textbox", { name: "Enter time" });
-    const user = await userEvent.setup();
-
-    await user.click(timeInput);
-    await user.keyboard("13:01");
-    await user.tab(timeInput);
-
-    expect(getByText(/at 1:01 PM/)).toBeTruthy();
-  });
-
-  it("shows an error message and disables the button when an invalid time is entered", async () => {
-    const { getByRole, getByText } = defaultComponentSetup();
-
-    const timeInput = getByRole("textbox", { name: "Enter time" });
-    const user = await userEvent.setup();
-
-    await user.click(timeInput);
-    await user.keyboard("I am not a time");
-    await user.tab(timeInput);
-
-    expect(getByText("Enter a valid date and time (HH:MM)")).toBeTruthy();
-    expect(
-      getByRole("button", { name: "Schedule Update", disabled: true }),
-    ).toBeTruthy();
-  });
-
-  it("disables the button when the scheduling is underway", () => {
-    const { getByRole } = renderWithProvider(<ScheduleSidebar />, {
-      preloadedState: {
-        suppliers: { value: suppliers },
-        contentfulSuppliers: { value: contentfulSuppliers },
-        appStatus: { value: AppStatus.SCHEDULING_UPDATES },
-      },
-    });
-
-    expect(
-      getByRole("button", { name: "Schedule Update", disabled: true }),
     ).toBeTruthy();
   });
 

--- a/src/constants/app-status.js
+++ b/src/constants/app-status.js
@@ -5,3 +5,6 @@ export const FETCHED_CONTENTFUL_SUPPLIERS = "fetchedContentfulSuppliers";
 export const PROCESS_SUPPLIERS = "processSuppliers";
 export const PROCESSING_SUPPLIERS = "processingSuppliers";
 export const PROCESSED_SUPPLIERS = "processedSuppliers";
+export const SCHEDULE_UPDATES = "scheduleUpdates";
+export const SCHEDULING_UPDATES = "schedulingUpdates";
+export const SCHEDULED_UPDATES = "scheduledUpdates";

--- a/src/constants/app-status.js
+++ b/src/constants/app-status.js
@@ -2,5 +2,6 @@ export const INITIALISED = "init";
 export const PARSING_FINISHED = "parsingFinished";
 export const FETCHING_CONTENTFUL_SUPPLIERS = "fetchingContentfulSuppliers";
 export const FETCHED_CONTENTFUL_SUPPLIERS = "fetchedContentfulSuppliers";
+export const PROCESS_SUPPLIERS = "processSuppliers";
 export const PROCESSING_SUPPLIERS = "processingSuppliers";
 export const PROCESSED_SUPPLIERS = "processedSuppliers";

--- a/src/locations/Page.jsx
+++ b/src/locations/Page.jsx
@@ -9,6 +9,7 @@ import MatchSidebar from "../components/sidebars/MatchSidebar";
 import ProcessScreen from "../components/screens/ProcessScreen";
 import ProcessSidebar from "../components/sidebars/ProcessSidebar";
 import ScheduleScreen from "../components/screens/ScheduleScreen";
+import ScheduleSidebar from "../components/sidebars/ScheduleSidebar";
 
 const Page = () => {
   const screen = useSelector((state) => state.screen.value);
@@ -36,6 +37,8 @@ const Page = () => {
         return <MatchSidebar></MatchSidebar>;
       case Screens.PROCESS:
         return <ProcessSidebar></ProcessSidebar>;
+      case Screens.SCHEDULE:
+        return <ScheduleSidebar></ScheduleSidebar>;
     }
   };
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,5 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { PARSING_FINISHED } from "../constants/app-status";
+import { TO_BE_PUBLISHED } from "../constants/supplier-status";
 
 export const getCanMatch = createSelector(
   [
@@ -69,5 +70,27 @@ export const getContentfulSuppliersNotInFile = createSelector(
         };
       })
       .filter((pair) => pair.supplier === undefined);
+  },
+);
+
+export const getContentfulIdsToBePublished = createSelector(
+  [
+    (state) => state.suppliers.value,
+    (state) => state.contentfulSuppliers.value,
+  ],
+  (suppliers, contentfulSuppliers) => {
+    return suppliers
+      .filter((s) => s.status === TO_BE_PUBLISHED)
+      .map((s) => {
+        return {
+          supplier: s,
+          contentfulSupplier: contentfulSuppliers.find((cs) => cs.id === s.id),
+        };
+      })
+      .filter((pair) => pair.contentfulSupplier !== undefined)
+      .map(
+        (pair) =>
+          pair.supplier.newContentfulId || pair.contentfulSupplier.contentfulId,
+      );
   },
 );

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,6 +1,9 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { PARSING_FINISHED } from "../constants/app-status";
-import { TO_BE_PUBLISHED } from "../constants/supplier-status";
+import {
+  CONTENTFUL_PUT_ERROR,
+  TO_BE_PUBLISHED,
+} from "../constants/supplier-status";
 
 export const getCanMatch = createSelector(
   [
@@ -92,5 +95,12 @@ export const getContentfulIdsToBePublished = createSelector(
         (pair) =>
           pair.supplier.newContentfulId || pair.contentfulSupplier.contentfulId,
       );
+  },
+);
+
+export const getAllContentfulActionsSuccessful = createSelector(
+  (state) => state.suppliers.value,
+  (suppliers) => {
+    return suppliers.every((s) => s.status !== CONTENTFUL_PUT_ERROR);
   },
 );

--- a/src/state/scheduleTimeSlice.js
+++ b/src/state/scheduleTimeSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  value: null,
+};
+
+export const scheduleTimeSlice = createSlice({
+  name: "scheduleTime",
+  initialState,
+  reducers: {
+    setScheduleTime: (state, action) => {
+      state.value = action.payload;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { setScheduleTime } = scheduleTimeSlice.actions;
+
+export default scheduleTimeSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -5,6 +5,7 @@ import suppliersReducer from "./state/supplierSlice";
 import uploadErrorsReducer from "./state/uploadErrorsSlice";
 import appStatusReducer from "./state/appStatusSlice";
 import contentfulSuppliersReducer from "./state/contentfulSupplierSlice";
+import scheduleTimeReducer from "./state/scheduleTimeSlice";
 
 // Create the root reducer separately so we can extract the RootState type
 const rootReducer = combineReducers({
@@ -13,6 +14,7 @@ const rootReducer = combineReducers({
   uploadErrors: uploadErrorsReducer,
   appStatus: appStatusReducer,
   contentfulSuppliers: contentfulSuppliersReducer,
+  scheduleTime: scheduleTimeReducer,
 });
 
 export const setupStore = (preloadedState) => {

--- a/test/fixtures/schedule-sidebar-state.js
+++ b/test/fixtures/schedule-sidebar-state.js
@@ -1,9 +1,4 @@
-import {
-  CONTENTFUL_PUT_ERROR,
-  PARSED,
-  TO_BE_PUBLISHED,
-  TO_BE_UNPUBLISHED,
-} from "../../src/constants/supplier-status";
+import { TO_BE_PUBLISHED } from "../../src/constants/supplier-status";
 
 const suppliers = [
   {

--- a/test/fixtures/schedule-sidebar-state.js
+++ b/test/fixtures/schedule-sidebar-state.js
@@ -1,0 +1,70 @@
+import {
+  CONTENTFUL_PUT_ERROR,
+  PARSED,
+  TO_BE_PUBLISHED,
+  TO_BE_UNPUBLISHED,
+} from "../../src/constants/supplier-status";
+
+const suppliers = [
+  {
+    name: "Supplier in Contentful 1",
+    rank: "1",
+    overallRating: "4.9",
+    complaintsRatings: "3.9",
+    contactRating: "2.9",
+    guaranteeRating: "1.9",
+    id: 1,
+    status: TO_BE_PUBLISHED,
+  },
+  {
+    name: "Supplier in Contentful 2",
+    rank: "2",
+    overallRating: "3.9",
+    complaintsRatings: "2.9",
+    contactRating: "1.9",
+    guaranteeRating: "0.9",
+    id: 2,
+    isSmall: true,
+    status: TO_BE_PUBLISHED,
+  },
+  {
+    name: "Supplier in Contentful 3",
+    rank: "2",
+    overallRating: "3.9",
+    complaintsRatings: "2.9",
+    contactRating: "1.9",
+    guaranteeRating: "0.9",
+    id: 3,
+    isSmall: true,
+    status: TO_BE_PUBLISHED,
+  },
+];
+
+const contentfulSuppliers = [
+  {
+    name: "Contentful supplier 1",
+    id: 1,
+    contentfulId: "1234",
+    dataAvailable: true,
+  },
+  {
+    name: "Contentful supplier 2",
+    id: 2,
+    contentfulId: "5678",
+    dataAvailable: false,
+  },
+  {
+    name: "Contentful supplier 3",
+    id: 3,
+    contentfulId: "9101",
+    dataAvailable: true,
+  },
+  {
+    name: "Supplier in Contentful but not in the spreadsheet",
+    id: 999,
+    contentfulId: "abc123",
+    dataAvailable: true,
+  },
+];
+
+export { contentfulSuppliers, suppliers };


### PR DESCRIPTION
Adds the sidebar to the scheduling screen, which:
- schedules a publish event for each supplier that has been created or updated
- schedules an unpublish event for each supplier that is no longer in the spreadsheet
- allows user to set the scheduling time

TO DO: error handling and feedback on successful scheduling
This will need some additional changes to the state so I'll do that in a separate PR