### PR TITLE
Feat/error handling

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -24,6 +24,16 @@
       "decision": "ignore",
       "madeAt": 1724326296868,
       "expiresAt": 1724931087812
+    },
+    "1099626|vite": {
+      "decision": "ignore",
+      "madeAt": 1726651573918,
+      "expiresAt": 1727256353443
+    },
+    "1099637|vite": {
+      "decision": "ignore",
+      "madeAt": 1726651580693,
+      "expiresAt": 1727256353443
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -6495,9 +6495,9 @@
       }
     },
     "node_modules/dset": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
-      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/components/ScheduleResult.jsx
+++ b/src/components/ScheduleResult.jsx
@@ -5,7 +5,6 @@ import {
   Modal,
   Stack,
   Subheading,
-  Table,
   TextLink,
 } from "@contentful/f36-components";
 import { useSelector } from "react-redux";
@@ -23,7 +22,7 @@ const ScheduleResult = ({ id, status }) => {
   const [showModal, setShowModal] = useState(false);
 
   const renderError = () => (
-    <Table.Cell>
+    <React.Fragment>
       <Stack flexDirection="row" alignItems="center">
         <ErrorCircleIcon variant="negative" />
         <TextLink variant="negative" onClick={() => setShowModal(true)}>
@@ -58,26 +57,20 @@ const ScheduleResult = ({ id, status }) => {
           </>
         )}
       </Modal>
-    </Table.Cell>
+    </React.Fragment>
   );
 
   if (status === ACTION_SCHEDULED) {
     return (
-      <Table.Cell>
-        <Stack flexDirection="row" alignItems="center">
-          <DoneIcon variant="positive" />
-          <TextLink variant="positive">OK</TextLink>
-        </Stack>
-      </Table.Cell>
+      <Stack flexDirection="row" alignItems="center">
+        <DoneIcon variant="positive" />
+        <TextLink variant="positive">OK</TextLink>
+      </Stack>
     );
   } else if (error) {
     return renderError();
   } else {
-    return (
-      <Table.Cell>
-        <MissingContent />
-      </Table.Cell>
-    );
+    return <MissingContent />;
   }
 };
 

--- a/src/components/ScheduleResult.jsx
+++ b/src/components/ScheduleResult.jsx
@@ -1,11 +1,66 @@
-import { Table } from "@contentful/f36-components";
+import {
+  Box,
+  List,
+  ListItem,
+  Modal,
+  Stack,
+  Subheading,
+  Table,
+  TextLink,
+} from "@contentful/f36-components";
 import { useSelector } from "react-redux";
+import { getError } from "../selectors";
+import { SCHEDULED_ACTION_PUT_ERROR } from "../constants/error-types";
+import { MissingContent } from "@contentful/f36-components";
+import React, { useState } from "react";
+import { ErrorCircleIcon } from "@contentful/f36-icons";
 
 const ScheduleResult = ({ contentfulId }) => {
-  const error = useSelector((state) => state.contentfulErrors.value);
-  console.log(error);
+  const error = useSelector((state) =>
+    getError(state, contentfulId, SCHEDULED_ACTION_PUT_ERROR),
+  );
+  const [showModal, setShowModal] = useState(false);
 
-  return <Table.Cell>{contentfulId}</Table.Cell>;
+  const renderError = () => (
+    <React.Fragment>
+      <Stack flexDirection="row" alignItems="center">
+        <ErrorCircleIcon variant="negative" />
+        <TextLink variant="negative" onClick={() => setShowModal(true)}>
+          Error
+        </TextLink>
+      </Stack>
+      <Modal
+        onClose={() => setShowModal(false)}
+        isShown={showModal}
+        size="fullScreen"
+      >
+        {() => (
+          <>
+            <Modal.Header
+              title="Error from Contentful"
+              onClose={() => setShowModal(false)}
+            />
+            <Modal.Content>
+              <Box marginBottom="spacingXl">
+                <Subheading>Error messages</Subheading>
+                <List>
+                  {JSON.parse(error.error).details.errors.map((e) => (
+                    <ListItem>{e.details}</ListItem>
+                  ))}
+                </List>
+              </Box>
+              <Subheading>Response</Subheading>
+              <code>
+                <pre style={{ whiteSpace: "pre-wrap" }}>{error.error}</pre>
+              </code>
+            </Modal.Content>
+          </>
+        )}
+      </Modal>
+    </React.Fragment>
+  );
+
+  return <Table.Cell>{error ? renderError() : <MissingContent />}</Table.Cell>;
 };
 
 export default ScheduleResult;

--- a/src/components/ScheduleResult.jsx
+++ b/src/components/ScheduleResult.jsx
@@ -13,16 +13,17 @@ import { getError } from "../selectors";
 import { SCHEDULED_ACTION_PUT_ERROR } from "../constants/error-types";
 import { MissingContent } from "@contentful/f36-components";
 import React, { useState } from "react";
-import { ErrorCircleIcon } from "@contentful/f36-icons";
+import { DoneIcon, ErrorCircleIcon } from "@contentful/f36-icons";
+import { ACTION_SCHEDULED } from "../constants/supplier-status";
 
-const ScheduleResult = ({ contentfulId }) => {
+const ScheduleResult = ({ id, status }) => {
   const error = useSelector((state) =>
-    getError(state, contentfulId, SCHEDULED_ACTION_PUT_ERROR),
+    getError(state, id, SCHEDULED_ACTION_PUT_ERROR),
   );
   const [showModal, setShowModal] = useState(false);
 
   const renderError = () => (
-    <React.Fragment>
+    <Table.Cell>
       <Stack flexDirection="row" alignItems="center">
         <ErrorCircleIcon variant="negative" />
         <TextLink variant="negative" onClick={() => setShowModal(true)}>
@@ -45,7 +46,7 @@ const ScheduleResult = ({ contentfulId }) => {
                 <Subheading>Error messages</Subheading>
                 <List>
                   {JSON.parse(error.error).details.errors.map((e) => (
-                    <ListItem>{e.details}</ListItem>
+                    <ListItem key={e.details}>{e.details}</ListItem>
                   ))}
                 </List>
               </Box>
@@ -57,10 +58,27 @@ const ScheduleResult = ({ contentfulId }) => {
           </>
         )}
       </Modal>
-    </React.Fragment>
+    </Table.Cell>
   );
 
-  return <Table.Cell>{error ? renderError() : <MissingContent />}</Table.Cell>;
+  if (status === ACTION_SCHEDULED) {
+    return (
+      <Table.Cell>
+        <Stack flexDirection="row" alignItems="center">
+          <DoneIcon variant="positive" />
+          <TextLink variant="positive">OK</TextLink>
+        </Stack>
+      </Table.Cell>
+    );
+  } else if (error) {
+    return renderError();
+  } else {
+    return (
+      <Table.Cell>
+        <MissingContent />
+      </Table.Cell>
+    );
+  }
 };
 
 export default ScheduleResult;

--- a/src/components/ScheduleResult.jsx
+++ b/src/components/ScheduleResult.jsx
@@ -1,0 +1,11 @@
+import { Table } from "@contentful/f36-components";
+import { useSelector } from "react-redux";
+
+const ScheduleResult = ({ contentfulId }) => {
+  const error = useSelector((state) => state.contentfulErrors.value);
+  console.log(error);
+
+  return <Table.Cell>{contentfulId}</Table.Cell>;
+};
+
+export default ScheduleResult;

--- a/src/components/ScheduleResult.spec.jsx
+++ b/src/components/ScheduleResult.spec.jsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, afterEach } from "vitest";
+
+import { render, cleanup } from "@testing-library/react";
+import UpdateResult from "./UpdateResult";
+import {
+  PARSED,
+  CONTENTFUL_PUT_ERROR,
+  TO_BE_PUBLISHED,
+} from "../constants/supplier-status";
+
+describe("UpdateResultComponent", () => {
+  afterEach(() => cleanup());
+
+  it("displays the missing info icon when the status is unrecognised", () => {
+    const { getByText } = render(<UpdateResult status={PARSED} />);
+    expect(getByText("—")).toBeTruthy();
+  });
+
+  it("displays an OK message when there is no error", () => {
+    const { getByText } = render(<UpdateResult status={TO_BE_PUBLISHED} />);
+    expect(getByText("OK")).toBeTruthy();
+  });
+
+  it("displays an error message when there is an error", () => {
+    const { getByText } = render(
+      <UpdateResult status={CONTENTFUL_PUT_ERROR} />,
+    );
+    expect(getByText("Errors during update")).toBeTruthy();
+  });
+});

--- a/src/components/ScheduleResult.spec.jsx
+++ b/src/components/ScheduleResult.spec.jsx
@@ -1,30 +1,95 @@
 import { describe, expect, it, afterEach } from "vitest";
 
-import { render, cleanup } from "@testing-library/react";
-import UpdateResult from "./UpdateResult";
+import { cleanup } from "@testing-library/react";
+import ScheduleResult from "./ScheduleResult";
+import { SCHEDULED_ACTION_PUT_ERROR } from "../constants/error-types";
+import { Table } from "@contentful/f36-components";
 import {
-  PARSED,
-  CONTENTFUL_PUT_ERROR,
+  ACTION_SCHEDULED,
   TO_BE_PUBLISHED,
 } from "../constants/supplier-status";
+import { renderWithProvider } from "../../test/utils/render-with-provider";
+import { userEvent } from "@testing-library/user-event";
 
-describe("UpdateResultComponent", () => {
+const error = {
+  status: 422,
+  statusText: "",
+  message: "Invalid request payload input",
+  details: {
+    errors: [
+      {
+        name: "datetime",
+        path: ["scheduledFor"],
+        details: '"scheduledFor.datetime" must be in the future',
+        value: "2024-08-31T23:01:00.000Z",
+      },
+    ],
+  },
+  request: {
+    url: "https://api.contentful.com:443/spaces/j9d3gn48j4iu/scheduled_actions",
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      "Content-Type": "application/vnd.contentful.management.v1+json",
+      "X-Contentful-User-Agent":
+        "app contentful.web-app; platform browser; sha 3114531e143db36b8f368acbf807c81037ecc659",
+    },
+    method: "POST",
+  },
+};
+
+const contentfulErrors = [
+  {
+    id: "1234",
+    errorType: SCHEDULED_ACTION_PUT_ERROR,
+    error: JSON.stringify(error),
+  },
+];
+
+const componentInTable = (status) => {
+  return (
+    <Table>
+      <Table.Body>
+        <Table.Row>
+          <ScheduleResult id="1234" status={status} />
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  );
+};
+
+describe("ScheduleResultComponent", () => {
   afterEach(() => cleanup());
+  it("shows OK when the scheduling was successful", () => {
+    const { getByText } = renderWithProvider(
+      componentInTable(ACTION_SCHEDULED),
+      {
+        preloadedState: {
+          contentfulErrors: { value: contentfulErrors },
+        },
+      },
+    );
 
-  it("displays the missing info icon when the status is unrecognised", () => {
-    const { getByText } = render(<UpdateResult status={PARSED} />);
-    expect(getByText("—")).toBeTruthy();
-  });
-
-  it("displays an OK message when there is no error", () => {
-    const { getByText } = render(<UpdateResult status={TO_BE_PUBLISHED} />);
     expect(getByText("OK")).toBeTruthy();
   });
 
-  it("displays an error message when there is an error", () => {
-    const { getByText } = render(
-      <UpdateResult status={CONTENTFUL_PUT_ERROR} />,
+  it("shows an error message when scheduling failed", async () => {
+    const { getByText } = renderWithProvider(
+      componentInTable(TO_BE_PUBLISHED),
+      {
+        preloadedState: {
+          contentfulErrors: { value: contentfulErrors },
+        },
+      },
     );
-    expect(getByText("Errors during update")).toBeTruthy();
+
+    const modalLink = getByText("Error");
+    expect(modalLink).toBeTruthy();
+
+    const user = await userEvent.setup();
+    await user.click(modalLink);
+
+    expect(
+      getByText('"scheduledFor.datetime" must be in the future'),
+    ).toBeTruthy();
   });
 });

--- a/src/components/ScheduleResult.spec.jsx
+++ b/src/components/ScheduleResult.spec.jsx
@@ -50,7 +50,9 @@ const componentInTable = (status) => {
     <Table>
       <Table.Body>
         <Table.Row>
-          <ScheduleResult id="1234" status={status} />
+          <Table.Cell>
+            <ScheduleResult id="1234" status={status} />
+          </Table.Cell>
         </Table.Row>
       </Table.Body>
     </Table>

--- a/src/components/SchedulingForm.jsx
+++ b/src/components/SchedulingForm.jsx
@@ -12,7 +12,7 @@ import {
 import { ErrorCircleIcon } from "@contentful/f36-icons";
 import { setAppStatus } from "../state/appStatusSlice";
 import { setScheduleTime } from "../state/scheduleTimeSlice";
-import { PROCESSED_SUPPLIERS, SCHEDULE_UPDATES } from "../constants/app-status";
+import { SCHEDULE_UPDATES, SCHEDULING_UPDATES } from "../constants/app-status";
 import { useDispatch, useSelector } from "react-redux";
 import { getAllContentfulActionsSuccessful } from "../selectors";
 
@@ -28,7 +28,7 @@ const SchedulingForm = () => {
   const date = useSelector((state) => state.scheduleTime.value);
 
   const allowScheduling =
-    appStatus === PROCESSED_SUPPLIERS &&
+    appStatus !== SCHEDULING_UPDATES &&
     uploadsSuccessful &&
     error === undefined;
 

--- a/src/components/SuppliersToBeCreated.jsx
+++ b/src/components/SuppliersToBeCreated.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import LoadingTableCell from "./LoadingTableCell";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import UpdateResult from "./UpdateResult";
+import ScheduleResult from "./ScheduleResult";
 
 const SuppliersToBeCreated = () => {
   const suppliersToBeCreated = useSelector(getSuppliersNotInContentful);
@@ -28,6 +29,7 @@ const SuppliersToBeCreated = () => {
           <LoadingTableCell status={pair.supplier.status}>
             <EntityStatusBadge entityStatus="published" />
           </LoadingTableCell>
+          <ScheduleResult id={pair.supplier.id} status={pair.supplier.status} />
           <Table.Cell>
             <TextLink
               onClick={() =>

--- a/src/components/SuppliersToBeCreated.jsx
+++ b/src/components/SuppliersToBeCreated.jsx
@@ -29,7 +29,12 @@ const SuppliersToBeCreated = () => {
           <LoadingTableCell status={pair.supplier.status}>
             <EntityStatusBadge entityStatus="published" />
           </LoadingTableCell>
-          <ScheduleResult id={pair.supplier.id} status={pair.supplier.status} />
+          <Table.Cell>
+            <ScheduleResult
+              id={pair.supplier.id}
+              status={pair.supplier.status}
+            />
+          </Table.Cell>
           <Table.Cell>
             <TextLink
               onClick={() =>

--- a/src/components/SuppliersToBeCreated.spec.jsx
+++ b/src/components/SuppliersToBeCreated.spec.jsx
@@ -82,8 +82,12 @@ describe("SuppliersToBeCreated component", () => {
     expect(successfulUpdateCells[3].textContent).toContain("published");
   });
 
+  it("doesn't display a result for the scheduling action yet", () => {
+    expect(successfulUpdateCells[4].textContent).toEqual("—");
+  });
+
   it("displays the view entry link when the create is successful", async () => {
-    const viewEntryLink = within(successfulUpdateCells[4]).getByText(
+    const viewEntryLink = within(successfulUpdateCells[5]).getByText(
       "View entry",
     );
     expect(viewEntryLink).toBeTruthy();

--- a/src/components/SuppliersToBeUpdated.jsx
+++ b/src/components/SuppliersToBeUpdated.jsx
@@ -29,7 +29,7 @@ const SuppliersToBeUpdated = () => {
           <LoadingTableCell status={pair.supplier.status}>
             <EntityStatusBadge entityStatus="published" />
           </LoadingTableCell>
-          <ScheduleResult contentfulId={pair.contentfulSupplier.contentfulId} />
+          <ScheduleResult id={pair.supplier.id} status={pair.supplier.status} />
           <Table.Cell>
             <TextLink
               onClick={() =>

--- a/src/components/SuppliersToBeUpdated.jsx
+++ b/src/components/SuppliersToBeUpdated.jsx
@@ -29,7 +29,12 @@ const SuppliersToBeUpdated = () => {
           <LoadingTableCell status={pair.supplier.status}>
             <EntityStatusBadge entityStatus="published" />
           </LoadingTableCell>
-          <ScheduleResult id={pair.supplier.id} status={pair.supplier.status} />
+          <Table.Cell>
+            <ScheduleResult
+              id={pair.supplier.id}
+              status={pair.supplier.status}
+            />
+          </Table.Cell>
           <Table.Cell>
             <TextLink
               onClick={() =>

--- a/src/components/SuppliersToBeUpdated.jsx
+++ b/src/components/SuppliersToBeUpdated.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import LoadingTableCell from "./LoadingTableCell";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import UpdateResult from "./UpdateResult";
+import ScheduleResult from "./ScheduleResult";
 
 const SuppliersToBeUpdated = () => {
   const suppliersToBeUpdated = useSelector(getMatchedSuppliersInContentful);
@@ -28,6 +29,7 @@ const SuppliersToBeUpdated = () => {
           <LoadingTableCell status={pair.supplier.status}>
             <EntityStatusBadge entityStatus="published" />
           </LoadingTableCell>
+          <ScheduleResult contentfulId={pair.contentfulSupplier.contentfulId} />
           <Table.Cell>
             <TextLink
               onClick={() =>

--- a/src/components/SuppliersToBeUpdated.spec.jsx
+++ b/src/components/SuppliersToBeUpdated.spec.jsx
@@ -82,8 +82,12 @@ describe("SuppliersToBeUpdated component", () => {
     expect(successfulUpdateCells[3].textContent).toContain("published");
   });
 
+  it("doesn't display a result for the scheduling action yet", () => {
+    expect(successfulUpdateCells[4].textContent).toEqual("—");
+  });
+
   it("displays the view entry link when the update is successful", async () => {
-    const viewEntryLink = within(successfulUpdateCells[4]).getByText(
+    const viewEntryLink = within(successfulUpdateCells[5]).getByText(
       "View entry",
     );
     expect(viewEntryLink).toBeTruthy();

--- a/src/components/screens/ScheduleScreen.jsx
+++ b/src/components/screens/ScheduleScreen.jsx
@@ -105,9 +105,10 @@ const ScheduleScreen = () => {
         <Table.Head>
           <Table.Row>
             <Table.Cell>Supplier</Table.Cell>
+            <Table.Cell>Update result</Table.Cell>
             <Table.Cell>Current Status</Table.Cell>
             <Table.Cell>Status after events</Table.Cell>
-            <Table.Cell>Result</Table.Cell>
+            <Table.Cell>Scheduling result</Table.Cell>
             <Table.Cell>Action</Table.Cell>
           </Table.Row>
         </Table.Head>

--- a/src/components/sidebars/ScheduleSidebar.jsx
+++ b/src/components/sidebars/ScheduleSidebar.jsx
@@ -23,6 +23,8 @@ import { scheduleAction } from "../../ContentfulWrapper";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { createClient } from "contentful-management";
 import SchedulingForm from "../SchedulingForm";
+import { addContentfulError } from "../../state/contentfulErrorsSlice";
+import { SCHEDULED_ACTION_PUT_ERROR } from "../../constants/error-types";
 
 const ScheduleSidebar = () => {
   const dispatch = useDispatch();
@@ -42,11 +44,31 @@ const ScheduleSidebar = () => {
       const contentfulActions = [];
 
       contentfulIdsToPublish.forEach((id) => {
-        contentfulActions.push(scheduleAction(id, date, "publish", cma));
+        contentfulActions.push(
+          scheduleAction(id, date, "publish", cma).catch((error) => {
+            dispatch(
+              addContentfulError({
+                errorType: SCHEDULED_ACTION_PUT_ERROR,
+                error: error.message,
+                contentfulId: id,
+              }),
+            );
+          }),
+        );
       });
 
       contentfulIdsToUnpublish.forEach((id) => {
-        contentfulActions.push(scheduleAction(id, date, "unpublish", cma));
+        contentfulActions.push(
+          scheduleAction(id, date, "unpublish", cma).catch((error) => {
+            dispatch(
+              addContentfulError({
+                errorType: SCHEDULED_ACTION_PUT_ERROR,
+                error: error.message,
+                contentfulId: id,
+              }),
+            );
+          }),
+        );
       });
 
       dispatch(setAppStatus(SCHEDULING_UPDATES));

--- a/src/constants/error-types.js
+++ b/src/constants/error-types.js
@@ -1,0 +1,1 @@
+export const SCHEDULED_ACTION_PUT_ERROR = "scheduledActionPutError";

--- a/src/constants/supplier-status.js
+++ b/src/constants/supplier-status.js
@@ -5,3 +5,4 @@ export const NOT_IN_SUPPLIER_DATA = "notInSupplierData";
 export const CONTENTFUL_PUT_ERROR = "contentfulPutError";
 export const TO_BE_PUBLISHED = "toBePublished";
 export const TO_BE_UNPUBLISHED = "toBeUnpublished";
+export const ACTION_SCHEDULED = "actionScheduled";

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -76,7 +76,7 @@ export const getContentfulSuppliersNotInFile = createSelector(
   },
 );
 
-export const getContentfulIdsToBePublished = createSelector(
+export const getSuppliersToBePublished = createSelector(
   [
     (state) => state.suppliers.value,
     (state) => state.contentfulSuppliers.value,
@@ -90,11 +90,7 @@ export const getContentfulIdsToBePublished = createSelector(
           contentfulSupplier: contentfulSuppliers.find((cs) => cs.id === s.id),
         };
       })
-      .filter((pair) => pair.contentfulSupplier !== undefined)
-      .map(
-        (pair) =>
-          pair.supplier.newContentfulId || pair.contentfulSupplier.contentfulId,
-      );
+      .filter((pair) => pair.contentfulSupplier !== undefined);
   },
 );
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -104,11 +104,9 @@ export const getAllContentfulActionsSuccessful = createSelector(
 export const getError = createSelector(
   [
     (state) => state.contentfulErrors.value,
-    (state, contentfulId) => contentfulId,
-    (state, contentfulId, errorType) => errorType,
+    (state, id) => id,
+    (state, id, errorType) => errorType,
   ],
-  (contentfulErrors, contentfulId, errorType) =>
-    contentfulErrors.find(
-      (e) => e.errorType === errorType && e.contentfulId === contentfulId,
-    ),
+  (contentfulErrors, id, errorType) =>
+    contentfulErrors.find((e) => e.errorType === errorType && e.id === id),
 );

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -104,3 +104,15 @@ export const getAllContentfulActionsSuccessful = createSelector(
     return suppliers.every((s) => s.status !== CONTENTFUL_PUT_ERROR);
   },
 );
+
+export const getError = createSelector(
+  [
+    (state) => state.contentfulErrors.value,
+    (state, contentfulId) => contentfulId,
+    (state, contentfulId, errorType) => errorType,
+  ],
+  (contentfulErrors, contentfulId, errorType) =>
+    contentfulErrors.find(
+      (e) => e.errorType === errorType && e.contentfulId === contentfulId,
+    ),
+);

--- a/src/state/contentfulErrorsSlice.js
+++ b/src/state/contentfulErrorsSlice.js
@@ -1,0 +1,33 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  value: [],
+};
+
+export const contentfulErrorsSlice = createSlice({
+  name: "contentfulErrors",
+  initialState,
+  reducers: {
+    addContentfulError: (state, action) => {
+      const { contentfulId, error, errorType } = action.payload;
+
+      const contentfulError = state.value.find(
+        (err) => err.contentfulId === contentfulId && err.type === errorType,
+      );
+      if (contentfulError !== undefined) {
+        contentfulError.error = error;
+      } else {
+        state.value.push({
+          contentfulId: contentfulId,
+          error: error,
+          errorType: errorType,
+        });
+      }
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { addContentfulError } = contentfulErrorsSlice.actions;
+
+export default contentfulErrorsSlice.reducer;

--- a/src/state/contentfulErrorsSlice.js
+++ b/src/state/contentfulErrorsSlice.js
@@ -9,16 +9,16 @@ export const contentfulErrorsSlice = createSlice({
   initialState,
   reducers: {
     addContentfulError: (state, action) => {
-      const { contentfulId, error, errorType } = action.payload;
+      const { id, error, errorType } = action.payload;
 
       const contentfulError = state.value.find(
-        (err) => err.contentfulId === contentfulId && err.type === errorType,
+        (err) => err.id === id && err.type === errorType,
       );
       if (contentfulError !== undefined) {
         contentfulError.error = error;
       } else {
         state.value.push({
-          contentfulId: contentfulId,
+          id: id,
           error: error,
           errorType: errorType,
         });

--- a/src/state/supplierSlice.js
+++ b/src/state/supplierSlice.js
@@ -21,6 +21,12 @@ export const suppliersSlice = createSlice({
       supplier.status = status;
       supplier.newContentfulId = newContentfulId;
     },
+    setSupplierStatus: (state, action) => {
+      const { id, status } = action.payload;
+
+      const supplier = state.value.find((s) => s.id === id);
+      supplier.status = status;
+    },
     setWhitelabelSupplierId: (state, action) => {
       const { id, whitelabelSupplierContentfulId } = action.payload;
 
@@ -35,6 +41,7 @@ export const {
   addSupplier,
   resetSuppliers,
   setSupplier,
+  setSupplierStatus,
   setWhitelabelSupplierId,
 } = suppliersSlice.actions;
 

--- a/src/store.js
+++ b/src/store.js
@@ -6,6 +6,7 @@ import uploadErrorsReducer from "./state/uploadErrorsSlice";
 import appStatusReducer from "./state/appStatusSlice";
 import contentfulSuppliersReducer from "./state/contentfulSupplierSlice";
 import scheduleTimeReducer from "./state/scheduleTimeSlice";
+import contentfulErrorReducer from "./state/contentfulErrorsSlice";
 
 // Create the root reducer separately so we can extract the RootState type
 const rootReducer = combineReducers({
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   appStatus: appStatusReducer,
   contentfulSuppliers: contentfulSuppliersReducer,
   scheduleTime: scheduleTimeReducer,
+  contentfulErrors: contentfulErrorReducer,
 });
 
 export const setupStore = (preloadedState) => {


### PR DESCRIPTION
Adds user feedback for whether the scheduling of publishing / unpublishing was successful or not for changes to an entry.
- `ScheduleResult` renders a modal with an error message (and the full error from Contentful) or an 'OK' message
- changes the scheduling form so that the button in only inactive when scheduling is happening, which allows for retrying scheduling if there is an error
- adding contentful errors into the state of the app (I made this a bit more general than is needed here because I will go and use the same approach to surface error in updates to entries too, in a different PR) - see #71 
