### PR TITLE
fix: only show error message list if present in response

### DIFF
--- a/src/components/ContentfulPutResult.jsx
+++ b/src/components/ContentfulPutResult.jsx
@@ -24,44 +24,52 @@ const ContentfulPutResult = ({
   );
   const [showModal, setShowModal] = useState(false);
 
-  const renderError = () => (
-    <React.Fragment>
-      <Stack flexDirection="row" alignItems="center">
-        <ErrorCircleIcon variant="negative" />
-        <TextLink variant="negative" onClick={() => setShowModal(true)}>
-          Error
-        </TextLink>
-      </Stack>
-      <Modal
-        onClose={() => setShowModal(false)}
-        isShown={showModal}
-        size="fullScreen"
-      >
-        {() => (
-          <>
-            <Modal.Header
-              title="Error from Contentful"
-              onClose={() => setShowModal(false)}
-            />
-            <Modal.Content>
-              <Box marginBottom="spacingXl">
-                <Subheading>Error messages</Subheading>
-                <List>
-                  {JSON.parse(error.error).details.errors.map((e) => (
-                    <ListItem key={e.details}>{e.details}</ListItem>
-                  ))}
-                </List>
-              </Box>
-              <Subheading>Response</Subheading>
-              <code>
-                <pre style={{ whiteSpace: "pre-wrap" }}>{error.error}</pre>
-              </code>
-            </Modal.Content>
-          </>
-        )}
-      </Modal>
-    </React.Fragment>
-  );
+  const renderError = () => {
+    const errorMessages = JSON.parse(error.error).details.errors;
+
+    return (
+      <React.Fragment>
+        <Stack flexDirection="row" alignItems="center">
+          <ErrorCircleIcon variant="negative" />
+          <TextLink variant="negative" onClick={() => setShowModal(true)}>
+            Error
+          </TextLink>
+        </Stack>
+        <Modal
+          onClose={() => setShowModal(false)}
+          isShown={showModal}
+          size="fullScreen"
+        >
+          {() => (
+            <>
+              <Modal.Header
+                title="Error from Contentful"
+                onClose={() => setShowModal(false)}
+              />
+              <Modal.Content>
+                {errorMessages ? (
+                  <Box marginBottom="spacingXl">
+                    <Subheading>Error messages</Subheading>
+                    <List>
+                      {errorMessages.map((e) => (
+                        <ListItem key={errorMessages.indexOf(e)}>
+                          {e.details}
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Box>
+                ) : null}
+                <Subheading>Response</Subheading>
+                <code>
+                  <pre style={{ whiteSpace: "pre-wrap" }}>{error.error}</pre>
+                </code>
+              </Modal.Content>
+            </>
+          )}
+        </Modal>
+      </React.Fragment>
+    );
+  };
 
   if (okStatus.includes(supplierStatus)) {
     return (

--- a/src/components/ContentfulPutResult.spec.jsx
+++ b/src/components/ContentfulPutResult.spec.jsx
@@ -64,8 +64,9 @@ const componentInTable = (supplierStatus) => {
   );
 };
 
-describe("ScheduleResultComponent", () => {
+describe("ContentfulPutResultComponent", () => {
   afterEach(() => cleanup());
+
   it("shows OK when the Contentful PUT request was successful", () => {
     const { getByText } = renderWithProvider(
       componentInTable(ACTION_SCHEDULED),
@@ -111,5 +112,37 @@ describe("ScheduleResultComponent", () => {
     );
 
     expect(getByText("—")).toBeTruthy();
+  });
+
+  it("shows just the error response from Contentful when the response is not parsable", async () => {
+    const differentError = {
+      ...error,
+      details: { message: "This error has no errors property." },
+    };
+    const { getByText, queryByText } = renderWithProvider(
+      componentInTable(TO_BE_PUBLISHED),
+      {
+        preloadedState: {
+          contentfulErrors: {
+            value: [
+              {
+                id: "1234",
+                errorType: SCHEDULED_ACTION_PUT_ERROR,
+                error: JSON.stringify(differentError),
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    const modalLink = getByText("Error");
+    expect(modalLink).toBeTruthy();
+
+    const user = await userEvent.setup();
+    await user.click(modalLink);
+
+    expect(queryByText("Error messages")).toBeFalsy();
+    expect(getByText(JSON.stringify(differentError))).toBeTruthy();
   });
 });


### PR DESCRIPTION
Sometimes the error responses from Contentful do not have the details.errors array - this handles the case when the`error.error.details.errors` is `undefined` (it just shows the whole response and doesn't try to extract error messages).