### PR TITLE
fix: add missing contact fields into Contentful supplier

### DIFF
--- a/src/helpers/mapSupplierToContentfulFields.js
+++ b/src/helpers/mapSupplierToContentfulFields.js
@@ -38,6 +38,10 @@ const mapSupplierToContentfulFields = (
   contentfulSupplier.fields.overallRating = { "en-GB": supplier.overallRating };
   contentfulSupplier.fields.contactEmail = { "en-GB": supplier.contactEmail };
   contentfulSupplier.fields.contactRating = { "en-GB": supplier.contactRating };
+  contentfulSupplier.fields.contactTime = { "en-GB": supplier.contactTime };
+  contentfulSupplier.fields.contactSocialMedia = {
+    "en-GB": supplier.contactSocialMedia,
+  };
   contentfulSupplier.fields.guaranteeRating = {
     "en-GB": supplier.guaranteeRating,
   };

--- a/test/fixtures/contentful-supplier.js
+++ b/test/fixtures/contentful-supplier.js
@@ -7,6 +7,8 @@ export const expectedFields = {
   overallRating: { "en-GB": 3.5 },
   contactEmail: { "en-GB": 99.3 },
   contactRating: { "en-GB": 3 },
+  contactSocialMedia: { "en-GB": "99,000" },
+  contactTime: { "en-GB": "00:11:30" },
   guaranteeRating: { "en-GB": 4.32 },
   supplierId: { "en-GB": 1 },
   slug: { "en-GB": "test-supplier" },


### PR DESCRIPTION
I missed a couple of fields when converting the supplier data into Contentful supplier entries.  This PR adds them in and updates the tests.