### PR TITLE
Tests/add feature tests to workflow

### DIFF
--- a/.github/workflows/deploy-stable-app.yml
+++ b/.github/workflows/deploy-stable-app.yml
@@ -2,7 +2,7 @@ name: Deploy stable app
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["Deploy unstable app"]
+    workflows: ["Feature tests"]
     types:
       - completed
 jobs:

--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -1,0 +1,35 @@
+name: Feature tests
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Deploy unstable app"]
+    types:
+      - completed
+jobs:
+  deploy:
+    environment:
+      name: unstable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Run feature tests
+        run: npm run e2etests
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright failiure report
+          path: playwright-report
+          retention-days: 1

--- a/features/auth.setup.js
+++ b/features/auth.setup.js
@@ -14,7 +14,7 @@ setup("authenticate", async ({ page }) => {
   );
   await expect(page.getByRole("button", { name: "Apps" })).toBeVisible();
   await page.goto(
-    `https://app.contentful.com/spaces/${process.env.VITE_REACT_APP_CONTENTFUL_SPACE_ID}/environments/master/apps/app_installations/${process.env.CONTENTFUL_APP_DEF_ID}/`,
+    `https://app.contentful.com/spaces/j9d3gn48j4iu/environments/master/apps/app_installations/${process.env.CONTENTFUL_APP_DEF_ID}/`,
   );
   await page.getByRole("button", { name: "Accept All" }).click();
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "prettier -w . && npm run lint:js -- --fix",
     "test": "npx vitest run",
+    "e2e-tests": "playwright test",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",


### PR DESCRIPTION
Adds feature tests to the workflows so they are run after the unstable app is deployed.  The deploy stable app job will only run if the feature tests have passed.

I am not sure that we will need to run the feature tests in production master environment, since that would involve altering real supplier data, so the space id is now hard coded.  If we need to run the tests there, I can come back and reinstate the variable.