### PR TITLE
Don't fetch test or archived suppliers from Contentful

### DIFF
--- a/src/ContentfulWrapper.js
+++ b/src/ContentfulWrapper.js
@@ -7,9 +7,14 @@ const getPublishedSuppliers = async (cma) => {
   const env = await space.getEnvironment(
     import.meta.env.VITE_REACT_APP_CONTENTFUL_ENV,
   );
-  return await env.getEntries({
+
+  let suppliers = await env.getEntries({
     content_type: "energySupplier",
+    "metadata.tags.sys.id[nin]": "test",
   });
+
+  // filter out archived suppliers
+  return suppliers.items.filter((s) => s.isArchived() === false);
 };
 
 const updateSupplier = async (pair, cma) => {

--- a/src/components/SuppliersInFileAndContentful.jsx
+++ b/src/components/SuppliersInFileAndContentful.jsx
@@ -7,12 +7,16 @@ import {
   Heading,
   Paragraph,
   Table,
+  TextLink,
 } from "@contentful/f36-components";
 import { getType } from "../helpers/getType";
 import LoadingTableRows from "./LoadingTableRows";
 import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
+import { useSDK } from "@contentful/react-apps-toolkit";
 
 const SuppliersInFileAndContentful = () => {
+  const sdk = useSDK();
+
   const suppliersInFileAndContentful = useSelector(
     getMatchedSuppliersInContentful,
   );
@@ -46,7 +50,20 @@ const SuppliersInFileAndContentful = () => {
                 return (
                   <Table.Row key={pair.supplier.id}>
                     <Table.Cell>{pair.supplier.name}</Table.Cell>
-                    <Table.Cell>{pair.contentfulSupplier.name}</Table.Cell>
+                    <Table.Cell>
+                      <TextLink
+                        onClick={() =>
+                          sdk.navigator.openEntry(
+                            pair.contentfulSupplier.contentfulId,
+                            {
+                              slideIn: true,
+                            },
+                          )
+                        }
+                      >
+                        {pair.contentfulSupplier.name}
+                      </TextLink>
+                    </Table.Cell>
                     <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
                   </Table.Row>
                 );

--- a/src/components/SuppliersInFileAndContentful.jsx
+++ b/src/components/SuppliersInFileAndContentful.jsx
@@ -4,6 +4,7 @@ import { getMatchedSuppliersInContentful } from "../selectors";
 import {
   Badge,
   Box,
+  EntityStatusBadge,
   Heading,
   Paragraph,
   Table,
@@ -37,6 +38,7 @@ const SuppliersInFileAndContentful = () => {
             <Table.Row>
               <Table.Cell>Supplier from spreadsheet</Table.Cell>
               <Table.Cell>Supplier in Contentful</Table.Cell>
+              <Table.Cell>Status</Table.Cell>
               <Table.Cell>Type</Table.Cell>
             </Table.Row>
           </Table.Head>
@@ -63,6 +65,11 @@ const SuppliersInFileAndContentful = () => {
                       >
                         {pair.contentfulSupplier.name}
                       </TextLink>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <EntityStatusBadge
+                        entityStatus={pair.contentfulSupplier.status}
+                      />
                     </Table.Cell>
                     <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
                   </Table.Row>

--- a/src/components/SuppliersInFileAndContentful.spec.jsx
+++ b/src/components/SuppliersInFileAndContentful.spec.jsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { userEvent } from "@testing-library/user-event";
 
 import SuppliersInFileAndContentful from "./SuppliersInFileAndContentful";
 import { within } from "@testing-library/react";
@@ -9,6 +10,19 @@ import {
 } from "../../test/fixtures/process-screen-state";
 import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
+const openEntryMock = vi.fn();
+
+vi.mock("@contentful/react-apps-toolkit", () => {
+  return {
+    useSDK: () => {
+      return {
+        navigator: {
+          openEntry: openEntryMock,
+        },
+      };
+    },
+  };
+});
 describe("SuppliersFoundInContentful component", () => {
   const { getByRole, queryByText } = renderWithProvider(
     <SuppliersInFileAndContentful />,
@@ -44,6 +58,18 @@ describe("SuppliersFoundInContentful component", () => {
       "I am another supplier in Contentful",
     );
     expect(columns[2].textContent).toContain("small");
+  });
+
+  it("displays a link to the supplier in Contentful", async () => {
+    const viewEntryLink = within(rows[1]).getByText(
+      "I am another supplier in Contentful",
+    );
+    expect(viewEntryLink).toBeTruthy();
+
+    const user = userEvent.setup();
+    await user.click(viewEntryLink);
+
+    expect(openEntryMock).toHaveBeenCalledOnce();
   });
 
   it("does not display suppliers in Contentful but not the file", () => {

--- a/src/components/SuppliersInFileAndContentful.spec.jsx
+++ b/src/components/SuppliersInFileAndContentful.spec.jsx
@@ -48,7 +48,8 @@ describe("SuppliersFoundInContentful component", () => {
     expect(columns[1].textContent).toContain(
       "I am a ranked supplier in Contentful",
     );
-    expect(columns[2].textContent).toContain("ranked");
+    expect(columns[2].textContent).toContain("published");
+    expect(columns[3].textContent).toContain("ranked");
   });
 
   it("displays the correct data for a small supplier", () => {
@@ -57,7 +58,8 @@ describe("SuppliersFoundInContentful component", () => {
     expect(columns[1].textContent).toContain(
       "I am another supplier in Contentful",
     );
-    expect(columns[2].textContent).toContain("small");
+    expect(columns[2].textContent).toContain("draft");
+    expect(columns[3].textContent).toContain("small");
   });
 
   it("displays a link to the supplier in Contentful", async () => {

--- a/src/components/SuppliersNotInContentful.jsx
+++ b/src/components/SuppliersNotInContentful.jsx
@@ -22,11 +22,12 @@ const SuppliersNotInContentful = () => {
           <Table.Row>
             <Table.Cell>Supplier from spreadsheet</Table.Cell>
             <Table.Cell>Type</Table.Cell>
+            <Table.Cell>Supplier Id</Table.Cell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
           <LoadingTableRows
-            colCount={3}
+            colCount={4}
             rowCount={3}
             showOnStatus={FETCHED_CONTENTFUL_SUPPLIERS}
           >
@@ -35,6 +36,7 @@ const SuppliersNotInContentful = () => {
                 <Table.Row key={pair.supplier.id}>
                   <Table.Cell>{pair.supplier.name}</Table.Cell>
                   <Table.Cell>{getType(pair.supplier.isSmall)}</Table.Cell>
+                  <Table.Cell>{pair.supplier.id}</Table.Cell>
                 </Table.Row>
               );
             })}

--- a/src/components/SuppliersNotInContentful.spec.jsx
+++ b/src/components/SuppliersNotInContentful.spec.jsx
@@ -34,6 +34,7 @@ describe("SuppliersNotInContentful component", () => {
       "I am a supplier that is in the file but not Contentful",
     );
     expect(columns[1].textContent).toContain("small");
+    expect(columns[2].textContent).toContain("9");
   });
 
   it("does not display suppliers in Contentful but not the file", () => {

--- a/src/components/SuppliersNotInFile.jsx
+++ b/src/components/SuppliersNotInFile.jsx
@@ -1,12 +1,20 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { getContentfulSuppliersNotInFile } from "../selectors";
-import { Box, Heading, Paragraph, Table } from "@contentful/f36-components";
+import {
+  Box,
+  Heading,
+  Paragraph,
+  Table,
+  TextLink,
+} from "@contentful/f36-components";
 import { getType } from "../helpers/getType";
 import LoadingTableRows from "./LoadingTableRows";
 import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
+import { useSDK } from "@contentful/react-apps-toolkit";
 
 const SuppliersNotInFile = () => {
+  const sdk = useSDK();
   const suppliersNotInFile = useSelector(getContentfulSuppliersNotInFile);
 
   const renderSuppliersNotInFile = () => {
@@ -27,7 +35,20 @@ const SuppliersNotInFile = () => {
             {suppliersNotInFile.map((pair) => {
               return (
                 <Table.Row key={pair.contentfulSupplier.name}>
-                  <Table.Cell>{pair.contentfulSupplier.name}</Table.Cell>
+                  <Table.Cell>
+                    <TextLink
+                      onClick={() =>
+                        sdk.navigator.openEntry(
+                          pair.contentfulSupplier.contentfulId,
+                          {
+                            slideIn: true,
+                          },
+                        )
+                      }
+                    >
+                      {pair.contentfulSupplier.name}
+                    </TextLink>
+                  </Table.Cell>
                   <Table.Cell>
                     {getType(!pair.contentfulSupplier.dataAvailable)}
                   </Table.Cell>

--- a/src/components/SuppliersNotInFile.jsx
+++ b/src/components/SuppliersNotInFile.jsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import { getContentfulSuppliersNotInFile } from "../selectors";
 import {
   Box,
+  EntityStatusBadge,
   Heading,
   Paragraph,
   Table,
@@ -24,13 +25,14 @@ const SuppliersNotInFile = () => {
           <Table.Row>
             <Table.Cell>Supplier from Contentful</Table.Cell>
             <Table.Cell>Type</Table.Cell>
+            <Table.Cell>Status</Table.Cell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
           <LoadingTableRows
             showOnStatus={FETCHED_CONTENTFUL_SUPPLIERS}
             rowCount={3}
-            colCount={2}
+            colCount={3}
           >
             {suppliersNotInFile.map((pair) => {
               return (
@@ -52,6 +54,11 @@ const SuppliersNotInFile = () => {
                   <Table.Cell>
                     {getType(!pair.contentfulSupplier.dataAvailable)}
                   </Table.Cell>
+                  <Table.Cell>
+                    <EntityStatusBadge
+                      entityStatus={pair.contentfulSupplier.status}
+                    />
+                  </Table.Cell>
                 </Table.Row>
               );
             })}
@@ -65,8 +72,8 @@ const SuppliersNotInFile = () => {
     <Box marginTop="spacingXl" marginBottom="spacingXl">
       <Heading as="h2">Suppliers to be unpublished</Heading>
       <Paragraph marginBottom="spacingL">
-        These suppliers are not in the spreadsheet but are in Contentful and
-        currently showing on the energy table. Nothing will happen to them yet.
+        These suppliers are not in the spreadsheet but are in Contentful.
+        Nothing will happen to them yet.
       </Paragraph>
       {suppliersNotInFile && suppliersNotInFile.length > 0 ? (
         renderSuppliersNotInFile()

--- a/src/components/SuppliersNotInFile.spec.jsx
+++ b/src/components/SuppliersNotInFile.spec.jsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { userEvent } from "@testing-library/user-event";
 
 import SuppliersNotInFile from "./SuppliersNotInFile";
 import { within } from "@testing-library/react";
@@ -9,6 +10,19 @@ import {
 } from "../../test/fixtures/process-screen-state";
 import { FETCHED_CONTENTFUL_SUPPLIERS } from "../constants/app-status";
 
+const openEntryMock = vi.fn();
+
+vi.mock("@contentful/react-apps-toolkit", () => {
+  return {
+    useSDK: () => {
+      return {
+        navigator: {
+          openEntry: openEntryMock,
+        },
+      };
+    },
+  };
+});
 describe("SuppliersNotInFile component", () => {
   const { getByRole, queryByText } = renderWithProvider(
     <SuppliersNotInFile />,
@@ -34,6 +48,18 @@ describe("SuppliersNotInFile component", () => {
       "I am a Contentful supplier that isn't in the file",
     );
     expect(columns[1].textContent).toContain("ranked");
+  });
+
+  it("displays a link to the supplier in Contentful", async () => {
+    const viewEntryLink = within(rows[0]).getByText(
+      "I am a Contentful supplier that isn't in the file",
+    );
+    expect(viewEntryLink).toBeTruthy();
+
+    const user = userEvent.setup();
+    await user.click(viewEntryLink);
+
+    expect(openEntryMock).toHaveBeenCalledOnce();
   });
 
   it("does not display suppliers in the file but not in Contentful", () => {

--- a/src/components/screens/ProcessScreen.jsx
+++ b/src/components/screens/ProcessScreen.jsx
@@ -23,26 +23,33 @@ const ProcessScreen = () => {
     if (status === AppStatus.FETCHING_CONTENTFUL_SUPPLIERS) {
       getPublishedSuppliers(cma).then((suppliers) => {
         suppliers.forEach((s) => {
-          dispatch(
-            addContentfulSupplier({
-              contentfulId: s.sys.id,
-              id: parseInt(s.fields.supplierId["en-GB"], 10),
-              name: s.fields.name["en-GB"],
-              dataAvailable: s.fields.dataAvailable["en-GB"],
-              status: getStatus(s),
-            }),
-          );
-
-          if (
-            s.fields.whitelabelSupplier &&
-            s.fields.whitelabelSupplier["en-GB"]
-          ) {
+          try {
             dispatch(
-              setWhitelabelSupplierId({
+              addContentfulSupplier({
+                contentfulId: s.sys.id,
                 id: parseInt(s.fields.supplierId["en-GB"], 10),
-                whitelabelSupplierContentfulId:
-                  s.fields.whitelabelSupplier["en-GB"].sys.id,
+                name: s.fields.name["en-GB"],
+                dataAvailable: s.fields.dataAvailable["en-GB"],
+                status: getStatus(s),
               }),
+            );
+
+            if (
+              s.fields.whitelabelSupplier &&
+              s.fields.whitelabelSupplier["en-GB"]
+            ) {
+              dispatch(
+                setWhitelabelSupplierId({
+                  id: parseInt(s.fields.supplierId["en-GB"], 10),
+                  whitelabelSupplierContentfulId:
+                    s.fields.whitelabelSupplier["en-GB"].sys.id,
+                }),
+              );
+            }
+          } catch (error) {
+            console.error(
+              "Cannot create contentfulSupplier from Contentful data",
+              { supplier: s, error: error },
             );
           }
         });

--- a/src/components/screens/ProcessScreen.jsx
+++ b/src/components/screens/ProcessScreen.jsx
@@ -10,6 +10,7 @@ import SuppliersNotInFile from "../SuppliersNotInFile";
 import { createClient } from "contentful-management";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { setWhitelabelSupplierId } from "../../state/supplierSlice";
+import { getStatus } from "../../helpers/getStatus";
 
 const ProcessScreen = () => {
   const sdk = useSDK();
@@ -21,13 +22,14 @@ const ProcessScreen = () => {
   useEffect(() => {
     if (status === AppStatus.FETCHING_CONTENTFUL_SUPPLIERS) {
       getPublishedSuppliers(cma).then((suppliers) => {
-        suppliers.items.forEach((s) => {
+        suppliers.forEach((s) => {
           dispatch(
             addContentfulSupplier({
               contentfulId: s.sys.id,
               id: parseInt(s.fields.supplierId["en-GB"], 10),
               name: s.fields.name["en-GB"],
               dataAvailable: s.fields.dataAvailable["en-GB"],
+              status: getStatus(s),
             }),
           );
 

--- a/src/components/screens/ProcessScreen.spec.jsx
+++ b/src/components/screens/ProcessScreen.spec.jsx
@@ -15,7 +15,7 @@ vi.mock("@contentful/react-apps-toolkit", () => {
 // we don't want to actually call Contentful in the tests
 vi.mock("../../ContentfulWrapper.js", () => {
   return {
-    getPublishedSuppliers: vi.fn().mockResolvedValue({ items: [] }),
+    getPublishedSuppliers: vi.fn().mockResolvedValue([]),
   };
 });
 

--- a/src/helpers/getStatus.js
+++ b/src/helpers/getStatus.js
@@ -1,0 +1,21 @@
+export const getStatus = (supplier) => {
+  let status = "unknown";
+
+  if (supplier.isPublished()) {
+    status = "published";
+  }
+
+  if (supplier.isDraft()) {
+    status = "draft";
+  }
+
+  if (supplier.isUpdated()) {
+    status = "changed";
+  }
+
+  if (supplier.isArchived()) {
+    status = "archived";
+  }
+
+  return status;
+};

--- a/test/fixtures/process-screen-state.js
+++ b/test/fixtures/process-screen-state.js
@@ -36,18 +36,21 @@ const contentfulSuppliers = [
     id: "1",
     contentfulId: "1234",
     dataAvailable: true,
+    status: "published",
   },
   {
     name: "I am another supplier in Contentful",
     id: "2",
     contentfulId: "5678",
     dataAvailable: false,
+    status: "draft",
   },
   {
     name: "I am a Contentful supplier that isn't in the file",
     id: "99",
     contentfulId: "9101",
     dataAvailable: true,
+    status: "published",
   },
 ];
 


### PR DESCRIPTION
- don't fetch `test` or `Archived` suppliers from Contentful when matching suppliers to those in the spreadsheet (we don't want to archive test suppliers, or republish archived suppliers)
- make it easier to check imported vs existing data in Contentful, by:
  - adding current supplier entry status to the tables in the `ProcessScreen`
  - adding `supplierId` to new suppliers in the `ProcessScreen`
  - adding links to existing suppliers in the `ProcessScreen`
   - adds some error logging when trying to convert Contentful JSON into contentful supplier objects on fetch