### PR TITLE
chore: switch gha runner

### DIFF
--- a/.github/workflows/deploy-stable-app.yml
+++ b/.github/workflows/deploy-stable-app.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     environment:
       name: stable
-    runs-on: ubuntu-latest
+    runs-on: runs-on
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-unstable-app.yml
+++ b/.github/workflows/deploy-unstable-app.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     environment:
       name: unstable
-    runs-on: ubuntu-latest
+    runs-on: runs-on
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Moving to use runs-on, as this is a private repo and so incurs costs from github if it uses their ubuntu runner.