### PR TITLE
chore: increase default test timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,8 @@ dotenv.config({ path: path.resolve(__dirname, ".env") });
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
   testDir: "./features",
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
Feature tests were periodically failing due to test timeout. Increasing the default timeout to 60000ms to remedy.