### PR TITLE
chore: increase default test timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ dotenv.config({ path: path.resolve(__dirname, ".env") });
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: 60_000,
+  timeout: 90_000,
   expect: { timeout: 10_000 },
   testDir: "./features",
   /* Run tests in files in parallel */


### PR DESCRIPTION
Feature tests were periodically failing due to test timeout. Increasing the default timeout to 90000ms to remedy.