### PR TITLE
chore: only deploy stable app on main branch

### DIFF
--- a/.github/workflows/deploy-stable-app.yml
+++ b/.github/workflows/deploy-stable-app.yml
@@ -2,6 +2,7 @@ name: Deploy stable app
 on:
   workflow_dispatch:
   workflow_run:
+    branches: [main]
     workflows: ["Feature tests"]
     types:
       - completed


### PR DESCRIPTION
At present if you manually run the step to deploy the unstable app it automatically deploys the stable app (if the feature tests pass). This means that it's not possible to deploy the unstable app to test changes without the risk of deploying it straight to production. Adding the branch option to the workflow adds a protection so that it will only deploy the stable app on the main branch