### PR TITLE
chore: update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,29 +8,39 @@ updates:
       react-dependencies:
         patterns:
           - "react*"
-          - "preact*"
           - "@testing-library/react"
-          - "@babel/react"
         update-types:
           - "minor"
           - "patch"
       major-react-dependencies:
         patterns:
           - "react*"
-          - "preact*"
           - "@testing-library/react"
         update-types:
           - "major"
       testing-dependencies:
         patterns:
+          - "@playwright/test"
           - "@testing-library/*"
-          - "@typescript-eslint/*"
+          - "@vitejs/plugin-react"
           - "eslint*"
-          - "jest*"
           - "prettier"
-          - "stylelint*"
+        update-types:
+          - "minor"
+          - "patch"
+      major-testing-dependencies:
+        patterns:
+          - "@playwright/test"
+          - "@testing-library/*"
+          - "@vitejs/plugin-react"
+          - "eslint*"
+          - "prettier"
         update-types:
           - "major"
+      contentful-dependencies:
+        patterns:
+          - "@contentful/*"
+        update-types:
           - "minor"
           - "patch"
       # everything else


### PR DESCRIPTION
Remove packages that aren't in this repo. Add additional groups for major-testing-dependencies and contentful-dependencies.