### PR TITLE
Chore/continuous deployment

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -1,0 +1,23 @@
+name: Continuous Deployment
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-unstable-app:
+    name: Deploy unstable app
+    uses: ./.github/workflows/deploy-unstable-app.yml
+    secrets: inherit
+
+  deploy-stable-app:
+    name: Deploy stable app
+    needs: [deploy-unstable-app]
+    uses: ./.github/workflows/deploy-stable-app.yml
+    secrets: inherit

--- a/.github/workflows/deploy-stable-app.yml
+++ b/.github/workflows/deploy-stable-app.yml
@@ -1,5 +1,5 @@
 name: Deploy stable app
-on: workflow_dispatch
+on: workflow_call
 jobs:
   deploy:
     environment:

--- a/.github/workflows/deploy-unstable-app.yml
+++ b/.github/workflows/deploy-unstable-app.yml
@@ -1,9 +1,8 @@
 name: Deploy unstable app
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+
 jobs:
   deploy:
     environment:

--- a/src/locations/Page.spec.jsx
+++ b/src/locations/Page.spec.jsx
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cleanup, screen } from "@testing-library/react";
 import { mockCma, mockSdk } from "../../test/mocks";
 import Page from "./Page";
 import { renderWithProvider } from "../../test/utils/render-with-provider";
@@ -8,13 +9,100 @@ vi.mock("@contentful/react-apps-toolkit", () => ({
   useCMA: () => mockCma,
 }));
 
+afterEach(() => {
+  cleanup();
+});
 describe("Page component", () => {
-  it("displays the upload file screen on app load", () => {
+  it("displays the upload file screen and sidebar on app load", () => {
     const { getByRole } = renderWithProvider(<Page />);
 
+    // Screen
     expect(
       getByRole("heading", {
         name: "Upload the data file",
+      }),
+    ).toBeTruthy();
+
+    // Sidebar
+    expect(
+      getByRole("heading", {
+        name: "UPLOAD SUPPLIERS",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("displays the match screen and sidebar when state is match", () => {
+    const { getByRole } = renderWithProvider(<Page />, {
+      preloadedState: {
+        screen: { value: "match" },
+      },
+    });
+
+    // Screen
+    expect(
+      screen.getByText("These are the suppliers found in the uploaded file."),
+    ).toBeTruthy();
+
+    // Sidebar
+    expect(
+      getByRole("heading", {
+        name: "MATCH SUPPLIERS",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("displays the process file screen and sidebar when state is process", () => {
+    const { getByRole } = renderWithProvider(<Page />, {
+      preloadedState: {
+        screen: { value: "process" },
+      },
+    });
+
+    // Screen
+    expect(
+      getByRole("heading", {
+        name: "Suppliers to be updated",
+      }),
+    ).toBeTruthy();
+
+    expect(
+      getByRole("heading", {
+        name: "Suppliers to be created",
+      }),
+    ).toBeTruthy();
+
+    expect(
+      getByRole("heading", {
+        name: "Suppliers to be unpublished",
+      }),
+    ).toBeTruthy();
+
+    // Sidebar
+    expect(
+      getByRole("heading", {
+        name: "PROCESS SUPPLIERS",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("displays the schedule screen and sidebar when state is schedule", () => {
+    const { getByRole } = renderWithProvider(<Page />, {
+      preloadedState: {
+        screen: { value: "schedule" },
+      },
+    });
+
+    // Screen
+    expect(
+      getByRole("heading", {
+        name: "Suppliers to be published",
+      }),
+    ).toBeTruthy();
+
+    // Sidebar
+    expect(
+      getByRole("heading", {
+        name: "SCHEDULE PUBLISH / UNPUBLISH",
       }),
     ).toBeTruthy();
   });


### PR DESCRIPTION
The app is already well tested when it comes to unit tests. This PR adds a set of unit tests to the page location to ensure that both correct screen and sidebar appear depending on the state. 

Adding continuous deployment workflow file (similar to the approach we use in the [contentful-apps](https://github.com/citizensadvice/contentful-apps/blob/main/.github/workflows/continuous-deployment.yml) repo).